### PR TITLE
Add unit tests for services and view models

### DIFF
--- a/RoomRoster/Services/NetworkService.swift
+++ b/RoomRoster/Services/NetworkService.swift
@@ -7,6 +7,12 @@
 
 import Foundation
 
+protocol NetworkServiceProtocol {
+    func fetchData<T: Codable>(from urlString: String) async throws -> T
+    func authorizedRequest(url: URL, method: String, jsonBody: [String: Any]) async throws -> URLRequest
+    func sendRequest(_ request: URLRequest) async throws
+}
+
 enum NetworkError: Error {
     case invalidURL
 }
@@ -56,3 +62,5 @@ struct NetworkService {
         }
     }
 }
+
+extension NetworkService: NetworkServiceProtocol {}

--- a/RoomRoster/Services/RoomService.swift
+++ b/RoomRoster/Services/RoomService.swift
@@ -13,12 +13,23 @@ enum RoomServiceError: Error {
 }
 
 struct RoomService {
-    private let sheetId = AppConfig.shared.sheetId
-    private let apiKey = AppConfig.shared.apiKey
+    private let sheetId: String
+    private let apiKey: String
+    private let networkService: NetworkServiceProtocol
+
+    init(
+        sheetId: String = AppConfig.shared.sheetId,
+        apiKey: String = AppConfig.shared.apiKey,
+        networkService: NetworkServiceProtocol = NetworkService.shared
+    ) {
+        self.sheetId = sheetId
+        self.apiKey = apiKey
+        self.networkService = networkService
+    }
 
     func fetchRooms() async throws -> [Room] {
         Logger.network("RoomService-fetchRooms")
-        let response: GoogleSheetsResponse = try await NetworkService.shared.fetchData(
+        let response: GoogleSheetsResponse = try await networkService.fetchData(
             from: "https://sheets.googleapis.com/v4/spreadsheets/\(sheetId)/values/Rooms!A:A?key=\(apiKey)"
         )
         return response.values.compactMap { $0.first }.filter { !$0.isEmpty }.map { Room(name: $0) }
@@ -31,12 +42,12 @@ struct RoomService {
         let url = "https://sheets.googleapis.com/v4/spreadsheets/\(sheetId)/values/Rooms:append?valueInputOption=USER_ENTERED"
         let payload: [String: Any] = ["values": [[trimmed]]]
         Logger.network("RoomService-addRoom")
-        let request = try await NetworkService.shared.authorizedRequest(
+        let request = try await networkService.authorizedRequest(
             url: URL(string: url)!,
             method: "POST",
             jsonBody: payload
         )
-        try await NetworkService.shared.sendRequest(request)
+        try await networkService.sendRequest(request)
 
         let rooms = try await fetchRooms()
         guard let newRoom = rooms.last(where: { $0.name.caseInsensitiveCompare(trimmed) == .orderedSame }) else {

--- a/RoomRoster/ViewModels/InventoryViewModel.swift
+++ b/RoomRoster/ViewModels/InventoryViewModel.swift
@@ -12,11 +12,20 @@ class InventoryViewModel: ObservableObject {
     @Published var items: [Item] = []
     @Published var rooms: [Room] = []
     @Published var recentLogs: [String: [String]] = [:]
-    private let service = InventoryService()
+    private let service: InventoryService
+    private let roomService: RoomService
+
+    init(
+        inventoryService: InventoryService = InventoryService(),
+        roomService: RoomService = RoomService()
+    ) {
+        self.service = inventoryService
+        self.roomService = roomService
+    }
 
     func loadRooms() async {
         do {
-            self.rooms = try await RoomService().fetchRooms()
+            self.rooms = try await roomService.fetchRooms()
         } catch {
             Logger.log(error, extra: ["description": "Failed to fetch rooms"])
         }
@@ -24,7 +33,7 @@ class InventoryViewModel: ObservableObject {
 
     func addRoom(name: String) async -> Room? {
         do {
-            return try await RoomService().addRoom(name: name)
+            return try await roomService.addRoom(name: name)
         } catch {
             Logger.log(error, extra: ["description": "Failed to add room"])
             return nil

--- a/RoomRosterTests/InventoryServiceTests.swift
+++ b/RoomRosterTests/InventoryServiceTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import RoomRoster
+
+final class InventoryServiceTests: XCTestCase {
+    func testFetchInventoryUsesNetwork() async throws {
+        let mock = MockNetworkService()
+        let expected = GoogleSheetsResponse(range: "Inventory!A:B", majorDimension: "ROWS", values: [["id","name"],["1","Item"]])
+        mock.fetchDataResults = [expected]
+        let service = InventoryService(sheetId: "sheet", apiKey: "key", networkService: mock)
+        let result = try await service.fetchInventory()
+        XCTAssertEqual(mock.fetchDataInputs.first, "https://sheets.googleapis.com/v4/spreadsheets/sheet/values/Inventory?key=key")
+        XCTAssertEqual(result.range, expected.range)
+    }
+
+    func testUpdateItemSendsPutRequest() async throws {
+        let mock = MockNetworkService()
+        let inventory = GoogleSheetsResponse(range: "Inventory", majorDimension: "ROWS", values: [["id","name"],["123","Old"]])
+        mock.fetchDataResults = [inventory]
+        let service = InventoryService(sheetId: "sheet", apiKey: "key", networkService: mock)
+        var item = Item.empty()
+        item.id = "123"
+        item.name = "New"
+        try await service.updateItem(item)
+        XCTAssertEqual(mock.authorizedRequests.first?.1, "PUT")
+        XCTAssertEqual(mock.sentRequests.count, 1)
+    }
+}

--- a/RoomRosterTests/ItemValidatorTests.swift
+++ b/RoomRosterTests/ItemValidatorTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import RoomRoster
+
+final class ItemValidatorTests: XCTestCase {
+    func testValidateNameThrowsForEmpty() {
+        XCTAssertThrowsError(try ItemValidator.validateName(" ")) { error in
+            XCTAssertEqual(error as? ItemValidationError, .emptyName)
+        }
+    }
+
+    func testValidateTagDuplicateThrows() {
+        let item = Item(id: "1", imageURL: "", name: "A", description: "", quantity: 1, dateAdded: "", estimatedPrice: nil, status: .available, lastKnownRoom: .empty(), updatedBy: "", lastUpdated: nil, propertyTag: PropertyTag(rawValue: "A0001"))
+        XCTAssertThrowsError(try ItemValidator.validateTag("A0001", currentItemID: nil, allItems: [item])) { error in
+            XCTAssertEqual(error as? ItemValidationError, .duplicateTag)
+        }
+    }
+
+    func testValidateTagSuccess() throws {
+        let tag = try ItemValidator.validateTag("A0001", currentItemID: nil, allItems: [])
+        XCTAssertEqual(tag.rawValue, "A0001")
+    }
+}

--- a/RoomRosterTests/MockNetworkService.swift
+++ b/RoomRosterTests/MockNetworkService.swift
@@ -1,0 +1,27 @@
+import Foundation
+@testable import RoomRoster
+
+enum MockError: Error { case noResponse }
+
+final class MockNetworkService: NetworkServiceProtocol {
+    var fetchDataInputs: [String] = []
+    var fetchDataResults: [Any] = []
+    func fetchData<T: Codable>(from urlString: String) async throws -> T {
+        fetchDataInputs.append(urlString)
+        guard !fetchDataResults.isEmpty else { throw MockError.noResponse }
+        let value = fetchDataResults.removeFirst()
+        return value as! T
+    }
+
+    var authorizedRequests: [(URL,String,[String:Any])] = []
+    var requestToReturn = URLRequest(url: URL(string: "https://example.com")!)
+    func authorizedRequest(url: URL, method: String, jsonBody: [String : Any]) async throws -> URLRequest {
+        authorizedRequests.append((url, method, jsonBody))
+        return requestToReturn
+    }
+
+    var sentRequests: [URLRequest] = []
+    func sendRequest(_ request: URLRequest) async throws {
+        sentRequests.append(request)
+    }
+}

--- a/RoomRosterTests/RoomServiceTests.swift
+++ b/RoomRosterTests/RoomServiceTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import RoomRoster
+
+final class RoomServiceTests: XCTestCase {
+    func testFetchRoomsParsesNames() async throws {
+        let mock = MockNetworkService()
+        let response = GoogleSheetsResponse(range: "Rooms", majorDimension: "ROWS", values: [["Room A"],["Room B"]])
+        mock.fetchDataResults = [response]
+        let service = RoomService(sheetId: "sheet", apiKey: "key", networkService: mock)
+        let rooms = try await service.fetchRooms()
+        XCTAssertEqual(mock.fetchDataInputs.first, "https://sheets.googleapis.com/v4/spreadsheets/sheet/values/Rooms!A:A?key=key")
+        XCTAssertEqual(rooms.map { $0.name }, ["Room A", "Room B"])
+    }
+
+    func testAddRoomWithEmptyNameThrows() async throws {
+        let service = RoomService(sheetId: "s", apiKey: "k", networkService: MockNetworkService())
+        await XCTAssertThrowsError(try await service.addRoom(name: "   ")) { error in
+            XCTAssertEqual(error as? RoomServiceError, .invalidName)
+        }
+    }
+}

--- a/RoomRosterTests/ViewModelTests.swift
+++ b/RoomRosterTests/ViewModelTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import RoomRoster
+
+final class ViewModelTests: XCTestCase {
+    func testInventoryViewModelLoadRooms() async throws {
+        let mock = MockNetworkService()
+        let response = GoogleSheetsResponse(range: "Rooms", majorDimension: "ROWS", values: [["R1"],["R2"]])
+        mock.fetchDataResults = [response]
+        let roomService = RoomService(sheetId: "s", apiKey: "k", networkService: mock)
+        let vm = InventoryViewModel(inventoryService: InventoryService(sheetId: "s", apiKey: "k", networkService: MockNetworkService()), roomService: roomService)
+        await vm.loadRooms()
+        XCTAssertEqual(vm.rooms.map { $0.name }, ["R1", "R2"])
+    }
+
+    func testCreateItemViewModelValidateTag() {
+        let vm = CreateItemViewModel(
+            inventoryService: InventoryService(sheetId: "s", apiKey: "k", networkService: MockNetworkService()),
+            roomService: RoomService(sheetId: "s", apiKey: "k", networkService: MockNetworkService()),
+            itemsProvider: { [Item(id: "1", imageURL: "", name: "", description: "", quantity: 1, dateAdded: "", estimatedPrice: nil, status: .available, lastKnownRoom: .empty(), updatedBy: "", lastUpdated: nil, propertyTag: PropertyTag(rawValue: "A0001"))] }
+        )
+        vm.propertyTagInput = "A0001"
+        vm.validateTag()
+        XCTAssertTrue(vm.showTagError)
+        XCTAssertEqual(vm.tagError, Strings.createItem.errors.tag.duplicate)
+    }
+}


### PR DESCRIPTION
## Summary
- allow injecting `NetworkServiceProtocol` into `InventoryService` and `RoomService`
- add dependency injection to `InventoryViewModel`
- create `MockNetworkService` for tests
- test `InventoryService`, `RoomService`, `ItemValidator`, and view models

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6876bf1cc8a4832cae7577d2937568aa