### PR TITLE
Remove unused imports

### DIFF
--- a/RoomRoster/Models/Item.swift
+++ b/RoomRoster/Models/Item.swift
@@ -6,8 +6,6 @@
 //
 
 import Foundation
-import SwiftData
-import SwiftUICore
 
 struct Item: Identifiable {
     var id: String


### PR DESCRIPTION
## Summary
- drop `SwiftData` and `SwiftUICore` imports from `Item.swift`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -project RoomRoster.xcodeproj -scheme RoomRoster -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.4' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876cd11e29c832cb2acd63660703f28