### PR TITLE
Handle invalid URL for RoomService

### DIFF
--- a/RoomRoster/Services/RoomService.swift
+++ b/RoomRoster/Services/RoomService.swift
@@ -42,8 +42,11 @@ struct RoomService {
         let url = "https://sheets.googleapis.com/v4/spreadsheets/\(sheetId)/values/Rooms:append?valueInputOption=USER_ENTERED"
         let payload: [String: Any] = ["values": [[trimmed]]]
         Logger.network("RoomService-addRoom")
+        guard let url = URL(string: url) else {
+            throw NetworkError.invalidURL
+        }
         let request = try await networkService.authorizedRequest(
-            url: URL(string: url)!,
+            url: url,
             method: "POST",
             jsonBody: payload
         )

--- a/RoomRosterTests/RoomServiceTests.swift
+++ b/RoomRosterTests/RoomServiceTests.swift
@@ -18,4 +18,12 @@ final class RoomServiceTests: XCTestCase {
             XCTAssertEqual(error as? RoomServiceError, .invalidName)
         }
     }
+
+    func testAddRoomWithInvalidURLThrows() async throws {
+        // Provide an invalid sheet ID to produce an invalid URL
+        let service = RoomService(sheetId: "invalid sheet id", apiKey: "k", networkService: MockNetworkService())
+        await XCTAssertThrowsError(try await service.addRoom(name: "Room")) { error in
+            XCTAssertEqual(error as? NetworkError, .invalidURL)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- guard against invalid URL in RoomService
- test NetworkError.invalidURL is thrown for invalid URL

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876cd0c7d78832c83e11d539f4e13dd