### PR TITLE
Move Sentry DSN to Secrets.plist

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,10 @@ RoomRoster is a SwiftUI-based inventory management application that integrates w
 
 ## Configuration
 
-The project requires two pieces of private configuration that are not checked into source control:
+The project requires private configuration that is not checked into source control:
 
 - **Firebase** – Copy `RoomRoster/GoogleService-Info-Example.plist` to `RoomRoster/GoogleService-Info.plist` and populate it with the credentials for your Firebase project. The resulting file is ignored by Git.
-- **Sentry** – Set the `SENTRY_DSN` environment variable before launching the app:
-
-```bash
-export SENTRY_DSN="https://examplePublicKey@o0.ingest.sentry.io/0"
-```
-
-If the variable is unset, Sentry will not send events.
+- **Secrets** – Copy `RoomRoster/Secrets-Example.plist` to `RoomRoster/Secrets.plist` and provide the following values:
+  - `SheetID` – The ID of the Google Sheet used by the app.
+  - `GoogleSheetsAPIKey` – Your Google Sheets API key.
+  - `SentryDSN` – *(Optional)* The DSN for Sentry crash reporting. If omitted, Sentry will not send events.

--- a/RoomRoster/AppConfig.swift
+++ b/RoomRoster/AppConfig.swift
@@ -12,6 +12,7 @@ struct AppConfig {
     
     let sheetId: String
     let apiKey: String
+    let sentryDSN: String?
     
     private init() {
         guard let url = Bundle.main.url(forResource: "Secrets", withExtension: "plist"),
@@ -24,8 +25,9 @@ struct AppConfig {
               let apiKey = plist["GoogleSheetsAPIKey"] as? String else {
             fatalError("Missing keys in Secrets.plist")
         }
-        
+
         self.sheetId = sheetId
         self.apiKey = apiKey
+        self.sentryDSN = plist["SentryDSN"] as? String
     }
 }

--- a/RoomRoster/Secrets-Example.plist
+++ b/RoomRoster/Secrets-Example.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>SheetID</key>
+    <string>YOUR_SHEET_ID</string>
+    <key>GoogleSheetsAPIKey</key>
+    <string>YOUR_SHEETS_API_KEY</string>
+    <key>SentryDSN</key>
+    <string>https://examplePublicKey@o0.ingest.sentry.io/0</string>
+</dict>
+</plist>
+

--- a/RoomRoster/Utilities/Logger.swift
+++ b/RoomRoster/Utilities/Logger.swift
@@ -26,7 +26,9 @@ enum LogCategory: String {
 struct Logger {
     static func initialize() {
         SentrySDK.start { options in
-            options.dsn = ProcessInfo.processInfo.environment["SENTRY_DSN"]
+            if let dsn = AppConfig.shared.sentryDSN {
+                options.dsn = dsn
+            }
             options.enableAutoSessionTracking = true
         }
 


### PR DESCRIPTION
## Summary
- add example Secrets.plist containing SentryDSN
- read Sentry DSN from Secrets.plist in AppConfig
- configure Logger to use the DSN from AppConfig
- update README instructions

## Testing
- `xcodebuild -version` *(fails: command not found)*
- `swift --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876d511cf10832c9284b0151e94ddb4