### PR TITLE
Simplify CI workflow

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -14,48 +14,14 @@ jobs:
     # ────────────────────────────── 1. Checkout ──────────────────────────────
     - uses: actions/checkout@v4
 
-    # ─────────────────────── 2. Stub plist files required at build ───────────
-    - name: Create dummy plist files
-      run: |
-        mkdir -p RoomRoster/RoomRoster/RoomRoster
-        cat > RoomRoster/RoomRoster/RoomRoster/Secrets.plist <<'EOF'
-        <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" \
-          "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        <plist version="1.0"><dict>
-          <key>API_KEY</key><string>${{ secrets.CI_FAKE_API_KEY || 'ci-fake-key' }}</string>
-          <key>SHEET_ID</key><string>${{ secrets.CI_FAKE_SHEET_ID || 'ci-fake-sheet-id' }}</string>
-        </dict></plist>
-        EOF
-
-        cat > RoomRoster/RoomRoster/RoomRoster/GoogleService-Info.plist <<'EOF'
-        <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" \
-          "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        <plist version="1.0"><dict>
-          <key>BUNDLE_ID</key><string>com.example.ci</string>
-        </dict></plist>
-        EOF
-
-    # ──────────────────── 3. Build + run all unit tests (iOS) ────────────────
+    # ─────────────────────── 2. Run CI test script ───────────────────────────
     - name: Run unit tests
-      env:
-        # Experimental language flags you already use
-        OTHER_SWIFT_FLAGS: >
-          -Xfrontend -enable-experimental-feature -Xfrontend AccessLevelOnImport
-          -Xfrontend -enable-experimental-feature -Xfrontend TypedThrows
-        NSUnbufferedIO: "YES"          # live log streaming
       run: |
-        set -o pipefail
-        xcodebuild test \
-          -project RoomRoster.xcodeproj \
-          -scheme RoomRoster \
-          -sdk iphonesimulator \
-          -destination 'platform=iOS Simulator,name=iPhone 14,OS=latest' \
-          CODE_SIGNING_ALLOWED=NO \
-          OTHER_SWIFT_FLAGS="$OTHER_SWIFT_FLAGS"
+        CI_FAKE_API_KEY=${{ secrets.CI_FAKE_API_KEY || 'ci-fake-key' }} \
+        CI_FAKE_SHEET_ID=${{ secrets.CI_FAKE_SHEET_ID || 'ci-fake-sheet-id' }} \
+        NSUnbufferedIO=YES Scripts/ci-test.sh
 
-    # ───────────── 4. Optional: capture DerivedData if the build fails ───────
+    # ───────────── 3. Optional: capture DerivedData if the build fails ───────
     - name: Upload DerivedData (on failure)
       if: failure()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -6,25 +6,30 @@ on:
 
 jobs:
   test:
-    # macos-15 image ships with Xcode 16.x (Swift 6) pre-installed.
+    # macos-15 → Xcode 16.x / Swift 6
     runs-on: macos-15
     timeout-minutes: 30
 
+    # ──────────────── SINGLE source of dummy values ────────────────
+    # • Local devs can ‘export CI_FAKE_API_KEY=…’ and re-use ci-test.sh
+    # • The script keeps its own “ci-fake-key” fallback, so nothing breaks
+    env:
+      CI_FAKE_API_KEY:  ${{ secrets.CI_FAKE_API_KEY  || 'ci-fake-key' }}
+      CI_FAKE_SHEET_ID: ${{ secrets.CI_FAKE_SHEET_ID || 'ci-fake-sheet-id' }}
+      NSUnbufferedIO:   "YES"
+
     steps:
-    # ────────────────────────────── 1. Checkout ──────────────────────────────
-    - uses: actions/checkout@v4
+      # 1️⃣  Checkout
+      - uses: actions/checkout@v4
 
-    # ─────────────────────── 2. Run CI test script ───────────────────────────
-    - name: Run unit tests
-      run: |
-        CI_FAKE_API_KEY=${{ secrets.CI_FAKE_API_KEY || 'ci-fake-key' }} \
-        CI_FAKE_SHEET_ID=${{ secrets.CI_FAKE_SHEET_ID || 'ci-fake-sheet-id' }} \
-        NSUnbufferedIO=YES Scripts/ci-test.sh
+      # 2️⃣  Run the same Bash script you already have
+      - name: Run unit tests
+        run: Scripts/ci-test.sh
 
-    # ───────────── 3. Optional: capture DerivedData if the build fails ───────
-    - name: Upload DerivedData (on failure)
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: DerivedData
-        path: ~/Library/Developer/Xcode/DerivedData
+      # 3️⃣  Upload DerivedData (only if the build fails)
+      - name: Upload DerivedData (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: DerivedData
+          path: ~/Library/Developer/Xcode/DerivedData

--- a/RoomRoster.xcodeproj/project.pbxproj
+++ b/RoomRoster.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		B6E684D42DD176D900EE608B /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		B6F9648F2DB021CD0093089A /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		B6F964912DB028E80093089A /* ImageUploadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadService.swift; sourceTree = "<group>"; };
+		41369DE8A719427EAB0ABC40 /* ci-test.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci-test.sh; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -225,6 +226,7 @@
 				767B058E2D4C5DC000566C25 /* RoomRoster */,
 				767B05A22D4C5DC400566C25 /* RoomRosterTests */,
 				767B05AC2D4C5DC400566C25 /* RoomRosterUITests */,
+				3E25700189AF441A8937F22E /* Scripts */,
 				767B058D2D4C5DC000566C25 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -303,6 +305,14 @@
 				B6A6D6DB2DD8FD4E00378BFF /* ErrorBanner.swift */,
 			);
 			path = Components;
+			sourceTree = "<group>";
+		};
+		3E25700189AF441A8937F22E /* Scripts */ = {
+			isa = PBXGroup;
+			children = (
+				41369DE8A719427EAB0ABC40 /* ci-test.sh */,
+			);
+			path = Scripts;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/Scripts/ci-test.sh
+++ b/Scripts/ci-test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+# Create dummy plist files expected by the build
+mkdir -p RoomRoster/RoomRoster/RoomRoster
+cat > RoomRoster/RoomRoster/RoomRoster/Secrets.plist <<'EOP'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+    <key>API_KEY</key><string>${CI_FAKE_API_KEY:-ci-fake-key}</string>
+    <key>SHEET_ID</key><string>${CI_FAKE_SHEET_ID:-ci-fake-sheet-id}</string>
+</dict></plist>
+EOP
+
+cat > RoomRoster/RoomRoster/RoomRoster/GoogleService-Info.plist <<'EOP'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+    <key>BUNDLE_ID</key><string>com.example.ci</string>
+</dict></plist>
+EOP
+
+OTHER_FLAGS="${OTHER_SWIFT_FLAGS:-"-Xfrontend -enable-experimental-feature -Xfrontend AccessLevelOnImport -Xfrontend -enable-experimental-feature -Xfrontend TypedThrows"}"
+
+xcodebuild test \
+    -project RoomRoster.xcodeproj \
+    -scheme RoomRoster \
+    -sdk iphonesimulator \
+    -destination 'platform=iOS Simulator,name=iPhone 14,OS=latest' \
+    CODE_SIGNING_ALLOWED=NO \
+    OTHER_SWIFT_FLAGS="$OTHER_FLAGS"

--- a/Scripts/ci-test.sh
+++ b/Scripts/ci-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Scripts/ci-test.sh  –  Build & run RoomRoster tests in CI
+# Scripts/ci-test.sh  —  Build & run RoomRoster tests in CI
 set -euo pipefail
 
 ###############################################################################
@@ -14,10 +14,11 @@ echo "📂 Working directory: $PWD"
 
 ###############################################################################
 # 1.  Stub the plist files the RoomRoster target expects
+#     (They live one folder below the project root, *not* two.)
 ###############################################################################
-mkdir -p RoomRoster/RoomRoster/RoomRoster
+mkdir -p RoomRoster/RoomRoster   # <- only TWO “RoomRoster” segments
 
-cat > RoomRoster/RoomRoster/RoomRoster/Secrets.plist <<EOF
+cat > RoomRoster/RoomRoster/Secrets.plist <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
   "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -27,7 +28,7 @@ cat > RoomRoster/RoomRoster/RoomRoster/Secrets.plist <<EOF
 </dict></plist>
 EOF
 
-cat > RoomRoster/RoomRoster/RoomRoster/GoogleService-Info.plist <<EOF
+cat > RoomRoster/RoomRoster/GoogleService-Info.plist <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
   "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -37,7 +38,7 @@ cat > RoomRoster/RoomRoster/RoomRoster/GoogleService-Info.plist <<EOF
 EOF
 
 echo "📝 Stub plists created:"
-ls -l RoomRoster/RoomRoster/RoomRoster/*.plist
+ls -l RoomRoster/RoomRoster/*.plist
 
 ###############################################################################
 # 2.  Choose a valid iOS-simulator UDID (robust across Xcode versions)

--- a/Scripts/ci-test.sh
+++ b/Scripts/ci-test.sh
@@ -1,31 +1,58 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Scripts/ci-test.sh
 set -euo pipefail
 
-# Create dummy plist files expected by the build
+###############################################################################
+# 1.  Stub the plist files your build expects
+###############################################################################
 mkdir -p RoomRoster/RoomRoster/RoomRoster
-cat > RoomRoster/RoomRoster/RoomRoster/Secrets.plist <<'EOP'
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0"><dict>
-    <key>API_KEY</key><string>${CI_FAKE_API_KEY:-ci-fake-key}</string>
-    <key>SHEET_ID</key><string>${CI_FAKE_SHEET_ID:-ci-fake-sheet-id}</string>
-</dict></plist>
-EOP
 
-cat > RoomRoster/RoomRoster/RoomRoster/GoogleService-Info.plist <<'EOP'
+cat > RoomRoster/RoomRoster/RoomRoster/Secrets.plist <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0"><dict>
-    <key>BUNDLE_ID</key><string>com.example.ci</string>
+  <key>API_KEY</key> <string>${CI_FAKE_API_KEY:-ci-fake-key}</string>
+  <key>SHEET_ID</key><string>${CI_FAKE_SHEET_ID:-ci-fake-sheet-id}</string>
 </dict></plist>
-EOP
+EOF
 
+cat > RoomRoster/RoomRoster/RoomRoster/GoogleService-Info.plist <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>BUNDLE_ID</key><string>com.example.ci</string>
+</dict></plist>
+EOF
+
+###############################################################################
+# 2.  Choose a simulator that actually exists on whatever Xcode is installed
+###############################################################################
+if [[ -n "${CI_SIM_UDID:-}" ]]; then           # let callers override
+  SIM_UDID="$CI_SIM_UDID"
+else
+  # first look for a booted device (makes local re-runs snappy)
+  SIM_UDID=$(xcrun simctl list devices booted | grep -m1 -oE '[A-F0-9\-]{36}' || true)
+  # otherwise grab the first available iOS device
+  if [[ -z "$SIM_UDID" ]]; then
+    SIM_UDID=$(xcrun simctl list devices available | awk '/iOS/{print $NF; exit}' | tr -d '()')
+  fi
+fi
+
+echo "ℹ️  Using simulator UDID: $SIM_UDID"
+xcrun simctl bootstatus "$SIM_UDID" -b >/dev/null
+
+###############################################################################
+# 3.  Run the tests (iOS slice only)
+###############################################################################
 OTHER_FLAGS="${OTHER_SWIFT_FLAGS:-"-Xfrontend -enable-experimental-feature -Xfrontend AccessLevelOnImport -Xfrontend -enable-experimental-feature -Xfrontend TypedThrows"}"
 
+set -o pipefail
 xcodebuild test \
-    -project RoomRoster.xcodeproj \
-    -scheme RoomRoster \
-    -sdk iphonesimulator \
-    -destination 'platform=iOS Simulator,name=iPhone 14,OS=latest' \
-    CODE_SIGNING_ALLOWED=NO \
-    OTHER_SWIFT_FLAGS="$OTHER_FLAGS"
+  -project RoomRoster.xcodeproj \
+  -scheme RoomRoster \
+  -sdk iphonesimulator \
+  -destination "id=$SIM_UDID" \
+  CODE_SIGNING_ALLOWED=NO \
+  OTHER_SWIFT_FLAGS="$OTHER_FLAGS"


### PR DESCRIPTION
## Summary
- create `ci-test.sh` helper script
- streamline workflow using new script
- remove CI instructions from README
- add script to Xcode project with correct indentation

## Testing
- `Scripts/ci-test.sh` *(fails: `xcodebuild` not found)*
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6876fb01cb10832cbd4fa7421af5c506