### PR TITLE
Fix ReportsViewModel build reference

### DIFF
--- a/RoomRoster.xcodeproj/project.pbxproj
+++ b/RoomRoster.xcodeproj/project.pbxproj
@@ -216,6 +216,7 @@
 				B6A6D6D92DD84F5000378BFF /* EditItemViewModel.swift */,
 				767E82CA2D8F1B2C00B48011 /* ItemDetailsViewModel.swift */,
 				767B05BC2D4C5E1700566C25 /* InventoryViewModel.swift */,
+				12FE82B0693248D49E8D77BB /* ReportsViewModel.swift */,
 				F1DB1AD2C44D425AB9A59153 /* SellItemViewModel.swift */,
                         );
 				path = ViewModels;


### PR DESCRIPTION
## Summary
- ensure `ReportsViewModel.swift` is referenced in the `ViewModels` group

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6877cbc20740832c989ff8100f6d257f