### PR TITLE
Fix PBX project indentation

### DIFF
--- a/RoomRoster.xcodeproj/project.pbxproj
+++ b/RoomRoster.xcodeproj/project.pbxproj
@@ -257,9 +257,9 @@
 				3758A93BD9E24318B74E47C2 /* SalesService.swift */,
 				C01D35FCE10EB02BEFD65D29 /* GmailService.swift */,
 				013FD279BBA14C5E965646A5 /* ReceiptPDFGenerator.swift */,
-				);
-path = Services;
-sourceTree = "<group>";
+                                );
+				path = Services;
+				sourceTree = "<group>";
                 };
 				767B05832D4C5DC000566C25 = {
 			isa = PBXGroup;


### PR DESCRIPTION
## Summary
- revert conditional import changes from `ReceiptPDFGenerator`
- fix tab indentation for the Services group in the Xcode project file

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6877e67e2364832ca0fec5e9d41d6763