### PR TITLE
Add sales reporting and listing

### DIFF
--- a/RoomRoster.xcodeproj/project.pbxproj
+++ b/RoomRoster.xcodeproj/project.pbxproj
@@ -73,8 +73,9 @@
 		B6F9649F2DB02BB60093089A /* FirebaseAppDistribution-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = B6F9649E2DB02BB60093089A /* FirebaseAppDistribution-Beta */; };
 		B6F964A12DB02C470093089A /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = B6F964A02DB02C470093089A /* FirebaseAuth */; };
 		B6F964A32DB02C470093089A /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = B6F964A22DB02C470093089A /* FirebaseStorage */; };
-		CE2487F2AA23494BBE56993D /* ReportsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12FE82B0693248D49E8D77BB /* ReportsViewModel.swift */; };
-		DE7D257232324BDDB96C6F37 /* RoomServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614508236AFA4269887FF35A /* RoomServiceTests.swift */; };
+                CE2487F2AA23494BBE56993D /* ReportsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12FE82B0693248D49E8D77BB /* ReportsViewModel.swift */; };
+                5A43DC562B7C4ABC9A123456 /* SalesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E32FE1D99B3B44E6A6801234 /* SalesViewModel.swift */; };
+                DE7D257232324BDDB96C6F37 /* RoomServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614508236AFA4269887FF35A /* RoomServiceTests.swift */; };
 		E9FBF450607D494DA1894333 /* MockNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF137618CD644A1997B55ED6 /* MockNetworkService.swift */; };
 		EC28A959CE63441E9F3C1048 /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EC0F7257914A11A7589F29 /* ShareSheet.swift */; };
 		FDB33D97700C2EF04190FA52 /* GmailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C01D35FCE10EB02BEFD65D29 /* GmailService.swift */; };
@@ -160,7 +161,8 @@
 		C01D35FCE10EB02BEFD65D29 /* GmailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GmailService.swift; sourceTree = "<group>"; };
 		C66A533C9D0B40A885DA2172 /* Condition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Condition.swift; sourceTree = "<group>"; };
 		E71B5019D5A040FCBB81807B /* ItemValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemValidatorTests.swift; sourceTree = "<group>"; };
-		F1DB1AD2C44D425AB9A59153 /* SellItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellItemViewModel.swift; sourceTree = "<group>"; };
+                F1DB1AD2C44D425AB9A59153 /* SellItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellItemViewModel.swift; sourceTree = "<group>"; };
+                E32FE1D99B3B44E6A6801234 /* SalesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -226,11 +228,12 @@
 				B6A6D6D92DD84F5000378BFF /* EditItemViewModel.swift */,
 				767E82CA2D8F1B2C00B48011 /* ItemDetailsViewModel.swift */,
 				767B05BC2D4C5E1700566C25 /* InventoryViewModel.swift */,
-				12FE82B0693248D49E8D77BB /* ReportsViewModel.swift */,
-				F1DB1AD2C44D425AB9A59153 /* SellItemViewModel.swift */,
-			);
-			path = ViewModels;
-			sourceTree = "<group>";
+                               12FE82B0693248D49E8D77BB /* ReportsViewModel.swift */,
+                               F1DB1AD2C44D425AB9A59153 /* SellItemViewModel.swift */,
+                                E32FE1D99B3B44E6A6801234 /* SalesViewModel.swift */,
+                        );
+                        path = ViewModels;
+                        sourceTree = "<group>";
 		};
 		765183BB2D8CD22300FBA72E /* Models */ = {
 			isa = PBXGroup;
@@ -533,10 +536,11 @@
 				B615ED202DE2BB15009BE623 /* Room.swift in Sources */,
 				8030ADBBCBB442E3B8D6D5FB /* Condition.swift in Sources */,
 				5E159DC99DBD4D6E817F1768 /* Sale.swift in Sources */,
-				3284B9D30A6B43858230535F /* SalesService.swift in Sources */,
-				7C37FF346999407A810EB18B /* SellItemViewModel.swift in Sources */,
-				A86D606B4FC641688F556F39 /* SalesView.swift in Sources */,
-				3B334618E2334DAFB69FB690 /* SellItemView.swift in Sources */,
+                                3284B9D30A6B43858230535F /* SalesService.swift in Sources */,
+                                7C37FF346999407A810EB18B /* SellItemViewModel.swift in Sources */,
+                                5A43DC562B7C4ABC9A123456 /* SalesViewModel.swift in Sources */,
+                                A86D606B4FC641688F556F39 /* SalesView.swift in Sources */,
+                                3B334618E2334DAFB69FB690 /* SellItemView.swift in Sources */,
 				FDB33D97700C2EF04190FA52 /* GmailService.swift in Sources */,
 				2867C19B08004E95B4BAD5B0 /* (null) in Sources */,
 			);

--- a/RoomRoster/Models/Sale.swift
+++ b/RoomRoster/Models/Sale.swift
@@ -12,6 +12,19 @@ struct Sale {
 }
 
 extension Sale {
+    init?(from row: [String]) {
+        let padded = row.padded(to: 8)
+        guard !padded[0].isEmpty,
+              let date = Date.fromShortString(padded[1]) else { return nil }
+        itemId = padded[0]
+        self.date = date
+        price = Double(padded[2])
+        condition = Condition(rawValue: padded[3]) ?? .new
+        buyerName = padded[4]
+        buyerContact = padded[5]
+        soldBy = padded[6]
+        department = padded[7]
+    }
     func toRow() -> [String] {
         [
             itemId,

--- a/RoomRoster/Services/SalesService.swift
+++ b/RoomRoster/Services/SalesService.swift
@@ -30,6 +30,13 @@ actor SalesService {
         try await networkService.sendRequest(request)
     }
 
+    func fetchSales() async throws -> [Sale] {
+        let url = "https://sheets.googleapis.com/v4/spreadsheets/\(sheetId)/values/Sales?key=\(apiKey)"
+        Logger.network("SalesService-fetchSales")
+        let sheet: GoogleSheetsResponse = try await networkService.fetchData(from: url)
+        return sheet.values.dropFirst().compactMap { Sale(from: $0) }
+    }
+
     func sendReceipts(to buyerEmail: String, sellerEmail: String, sale: Sale) async {
         let subject = "Sale Receipt for \(sale.itemId)"
         let body = "Item sold on \(sale.date.toShortString()) for \(sale.price ?? 0)"

--- a/RoomRoster/Utilities/Strings.swift
+++ b/RoomRoster/Utilities/Strings.swift
@@ -226,6 +226,9 @@ struct Strings {
         static let searchPlaceholder = "Search items..."
         static let searchResults = "Results"
         static let clearSearch = "Clear"
+        static let salesOverview = "Sales Overview"
+        static let totalSold = "Total Sold"
+        static let totalRevenue = "Total Revenue"
     }
 
     // MARK: - SheetsView
@@ -238,6 +241,8 @@ struct Strings {
     struct sales {
         static let title = "Sales"
         static let comingSoon = "Sales - Coming Soon"
+        static let emptyState = "No sales recorded"
+        static let failedToLoad = "Failed to load sales. Please try again."
     }
 
     // MARK: - SellItemView

--- a/RoomRoster/ViewModels/SalesViewModel.swift
+++ b/RoomRoster/ViewModels/SalesViewModel.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+@MainActor
+final class SalesViewModel: ObservableObject {
+    @Published var sales: [Sale] = []
+    @Published var errorMessage: String? = nil
+
+    private let salesService: SalesService
+
+    init(salesService: SalesService = .init()) {
+        self.salesService = salesService
+    }
+
+    func loadSales() async {
+        do {
+            sales = try await salesService.fetchSales()
+        } catch {
+            Logger.log(error, extra: ["description": "Failed to load sales"])
+            errorMessage = Strings.sales.failedToLoad
+        }
+    }
+}

--- a/RoomRoster/Views/ItemDetailsView.swift
+++ b/RoomRoster/Views/ItemDetailsView.swift
@@ -119,24 +119,25 @@ struct ItemDetailsView: View {
                 Spacer()
                 HStack {
                     Spacer()
-                    Button(l10n.editItem) {
-                        Logger.action("Pressed Edit Button")
-                        isEditing = true
-                    }
-                    .padding()
-                    .background(Color.blue)
-                    .foregroundColor(.white)
-                    .cornerRadius(10)
-                    .padding()
+                    VStack {
+                        Button(l10n.editItem) {
+                            Logger.action("Pressed Edit Button")
+                            isEditing = true
+                        }
+                        .padding()
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
 
-                    Button(Strings.sellItem.title) {
-                        Logger.action("Pressed Sell Button")
-                        showingSellSheet = true
+                        Button(Strings.sellItem.title) {
+                            Logger.action("Pressed Sell Button")
+                            showingSellSheet = true
+                        }
+                        .padding()
+                        .background(Color.green)
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
                     }
-                    .padding()
-                    .background(Color.green)
-                    .foregroundColor(.white)
-                    .cornerRadius(10)
                     .padding()
                 }
             }

--- a/RoomRoster/Views/ReportsView.swift
+++ b/RoomRoster/Views/ReportsView.swift
@@ -19,6 +19,8 @@ struct ReportsView: View {
                     }
                     Toggle(Strings.inventory.includeHistoryToggle, isOn: $viewModel.includeHistoryInSearch)
                         .font(.subheadline)
+                    Toggle(Strings.inventory.includeSoldToggle, isOn: $viewModel.includeSoldItems)
+                        .font(.subheadline)
                 }
 
                 if !viewModel.query.isEmpty {
@@ -46,6 +48,19 @@ struct ReportsView: View {
                         Text(l10n.totalValue)
                         Spacer()
                         Text("$\(viewModel.totalValue, specifier: "%.2f")")
+                    }
+                }
+
+                Section(header: Text(l10n.salesOverview)) {
+                    HStack {
+                        Text(l10n.totalSold)
+                        Spacer()
+                        Text(String(viewModel.sales.count))
+                    }
+                    HStack {
+                        Text(l10n.totalRevenue)
+                        Spacer()
+                        Text("$\(viewModel.totalSalesValue, specifier: "%.2f")")
                     }
                 }
 

--- a/RoomRoster/Views/SalesView.swift
+++ b/RoomRoster/Views/SalesView.swift
@@ -3,11 +3,39 @@ import SwiftUI
 private typealias l10n = Strings.sales
 
 struct SalesView: View {
+    @StateObject private var viewModel = SalesViewModel()
+
     var body: some View {
-        Text(l10n.comingSoon)
-            .font(.title)
-            .foregroundColor(.secondary)
+        NavigationView {
+            List {
+                if let error = viewModel.errorMessage {
+                    ErrorBanner(message: error)
+                }
+
+                if viewModel.sales.isEmpty {
+                    Text(l10n.emptyState)
+                        .foregroundColor(.secondary)
+                } else {
+                    ForEach(Array(viewModel.sales.enumerated()), id: \.offset) { i, sale in
+                        VStack(alignment: .leading) {
+                            Text(sale.itemId)
+                                .font(.headline)
+                            HStack {
+                                Text(sale.date.toShortString())
+                                Spacer()
+                                if let price = sale.price {
+                                    Text("$\(price, specifier: "%.2f")")
+                                }
+                            }
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                        }
+                    }
+                }
+            }
             .navigationTitle(l10n.title)
-            .onAppear { Logger.page("SalesView") }
+        }
+        .task { await viewModel.loadSales() }
+        .onAppear { Logger.page("SalesView") }
     }
 }

--- a/RoomRosterTests/SalesServiceTests.swift
+++ b/RoomRosterTests/SalesServiceTests.swift
@@ -10,4 +10,14 @@ final class SalesServiceTests: XCTestCase {
         XCTAssertEqual(mock.authorizedRequests.first?.1, "POST")
         XCTAssertEqual(mock.sentRequests.count, 1)
     }
+
+    func testFetchSalesUsesNetwork() async throws {
+        let mock = MockNetworkService()
+        let sheet = GoogleSheetsResponse(range: "Sales", majorDimension: "ROWS", values: [["id","date","price","cond","buyer","contact","sold","dept"],["1","1/1/2025","5","Good","B","c","S","D"]])
+        mock.fetchDataResults = [sheet]
+        let service = SalesService(sheetId: "sheet", apiKey: "key", networkService: mock)
+        let sales = try await service.fetchSales()
+        XCTAssertEqual(mock.fetchDataInputs.first, "https://sheets.googleapis.com/v4/spreadsheets/sheet/values/Sales?key=key")
+        XCTAssertEqual(sales.first?.itemId, "1")
+    }
 }


### PR DESCRIPTION
## Summary
- show list of sales in Sales tab
- add SalesViewModel for loading Sales sheet
- parse sales from sheet and fetch via service
- display sales overview in Reports
- filter sold items in Reports search with toggle
- stack Sell button vertically with Edit button
- test SalesService.fetchSales

## Testing
- `xcodebuild` not available in container


------
https://chatgpt.com/codex/tasks/task_e_6877f127db50832c89a19045164b7235