### PR TITLE
Enable sales detail view navigation and refresh

### DIFF
--- a/RoomRoster.xcodeproj/project.pbxproj
+++ b/RoomRoster.xcodeproj/project.pbxproj
@@ -38,8 +38,9 @@
 		7DB3EA08C76F4E048B379677 /* ViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC01C73ED7A4FBC9EECB3D3 /* ViewModelTests.swift */; };
 		8030ADBBCBB442E3B8D6D5FB /* Condition.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66A533C9D0B40A885DA2172 /* Condition.swift */; };
 		A787349732EA468CB09F1E52 /* SalesServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC8C5F5D40748AD93602E33 /* SalesServiceTests.swift */; };
-		A86D606B4FC641688F556F39 /* SalesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6624E3822EF84521B07B00F3 /* SalesView.swift */; };
-		B612436C2DB03BA000B9098B /* ImagePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B612436B2DB03BA000B9098B /* ImagePickerView.swift */; };
+                A86D606B4FC641688F556F39 /* SalesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6624E3822EF84521B07B00F3 /* SalesView.swift */; };
+                C616CDE1A2B34C5D67890ABE /* SalesDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C616CDE1A2B34C5D67890ABD /* SalesDetailsView.swift */; };
+                B612436C2DB03BA000B9098B /* ImagePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B612436B2DB03BA000B9098B /* ImagePickerView.swift */; };
 		B615ED1C2DE12A16009BE623 /* Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = B615ED1B2DE12A16009BE623 /* Status.swift */; };
 		B615ED1E2DE226E1009BE623 /* PropertyTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = B615ED1D2DE226E1009BE623 /* PropertyTag.swift */; };
 		B615ED202DE2BB15009BE623 /* Room.swift in Sources */ = {isa = PBXBuildFile; fileRef = B615ED1F2DE2BB15009BE623 /* Room.swift */; };
@@ -104,8 +105,9 @@
 		3758A93BD9E24318B74E47C2 /* SalesService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesService.swift; sourceTree = "<group>"; };
 		4AC01C73ED7A4FBC9EECB3D3 /* ViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelTests.swift; sourceTree = "<group>"; };
 		614508236AFA4269887FF35A /* RoomServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomServiceTests.swift; sourceTree = "<group>"; };
-		6624E3822EF84521B07B00F3 /* SalesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesView.swift; sourceTree = "<group>"; };
-		68CAB974B03A4708BB968FC8 /* SellItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellItemView.swift; sourceTree = "<group>"; };
+                6624E3822EF84521B07B00F3 /* SalesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesView.swift; sourceTree = "<group>"; };
+                C616CDE1A2B34C5D67890ABD /* SalesDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesDetailsView.swift; sourceTree = "<group>"; };
+                68CAB974B03A4708BB968FC8 /* SellItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellItemView.swift; sourceTree = "<group>"; };
 		70EC0F7257914A11A7589F29 /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
 		767B058C2D4C5DC000566C25 /* RoomRoster.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RoomRoster.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		767B058F2D4C5DC000566C25 /* RoomRosterApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomRosterApp.swift; sourceTree = "<group>"; };
@@ -215,9 +217,10 @@
 				B65F71262DE6493600310D40 /* ReportsView.swift */,
 				B65F712A2DE6495900310D40 /* SettingsView.swift */,
 				B65F71282DE6494A00310D40 /* SheetsView.swift */,
-				6624E3822EF84521B07B00F3 /* SalesView.swift */,
-				68CAB974B03A4708BB968FC8 /* SellItemView.swift */,
-			);
+                                6624E3822EF84521B07B00F3 /* SalesView.swift */,
+                                C616CDE1A2B34C5D67890ABD /* SalesDetailsView.swift */,
+                                68CAB974B03A4708BB968FC8 /* SellItemView.swift */,
+                        );
 			path = Views;
 			sourceTree = "<group>";
 		};
@@ -540,8 +543,9 @@
                                 7C37FF346999407A810EB18B /* SellItemViewModel.swift in Sources */,
                                 5A43DC562B7C4ABC9A123456 /* SalesViewModel.swift in Sources */,
                                 A86D606B4FC641688F556F39 /* SalesView.swift in Sources */,
+                                C616CDE1A2B34C5D67890ABE /* SalesDetailsView.swift in Sources */,
                                 3B334618E2334DAFB69FB690 /* SellItemView.swift in Sources */,
-				FDB33D97700C2EF04190FA52 /* GmailService.swift in Sources */,
+                                FDB33D97700C2EF04190FA52 /* GmailService.swift in Sources */,
 				2867C19B08004E95B4BAD5B0 /* (null) in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RoomRoster/Utilities/Strings.swift
+++ b/RoomRoster/Utilities/Strings.swift
@@ -259,4 +259,16 @@ struct Strings {
         static let soldBy = "Sold By"
         static let department = "Department"
     }
+
+    // MARK: - SaleDetailsView
+    struct saleDetails {
+        static let title = "Sale Details"
+        static let price = "Price:"
+        static let condition = "Condition:"
+        static let date = "Date:"
+        static let buyerName = "Buyer:"
+        static let buyerContact = "Contact:"
+        static let soldBy = "Sold By:"
+        static let department = "Department:"
+    }
 }

--- a/RoomRoster/ViewModels/SalesViewModel.swift
+++ b/RoomRoster/ViewModels/SalesViewModel.swift
@@ -4,19 +4,35 @@ import SwiftUI
 final class SalesViewModel: ObservableObject {
     @Published var sales: [Sale] = []
     @Published var errorMessage: String? = nil
+    @Published private(set) var itemsById: [String: Item] = [:]
 
     private let salesService: SalesService
+    private let inventoryService: InventoryService
 
-    init(salesService: SalesService = .init()) {
+    init(
+        salesService: SalesService = .init(),
+        inventoryService: InventoryService = .init()
+    ) {
         self.salesService = salesService
+        self.inventoryService = inventoryService
     }
 
     func loadSales() async {
         do {
+            itemsById = [:]
             sales = try await salesService.fetchSales()
+            for sale in sales {
+                if let item = try? await inventoryService.fetchItem(withId: sale.itemId) {
+                    itemsById[sale.itemId] = item
+                }
+            }
         } catch {
             Logger.log(error, extra: ["description": "Failed to load sales"])
             errorMessage = Strings.sales.failedToLoad
         }
+    }
+
+    func itemName(for sale: Sale) -> String {
+        itemsById[sale.itemId]?.name ?? sale.itemId
     }
 }

--- a/RoomRoster/Views/ReportsView.swift
+++ b/RoomRoster/Views/ReportsView.swift
@@ -102,6 +102,7 @@ struct ReportsView: View {
             }
         }
         .task { await viewModel.loadData() }
+        .refreshable { await viewModel.loadData() }
         .onAppear { Logger.page("ReportsView") }
     }
 

--- a/RoomRoster/Views/SalesDetailsView.swift
+++ b/RoomRoster/Views/SalesDetailsView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+private typealias l10n = Strings.saleDetails
+
+struct SalesDetailsView: View {
+    let sale: Sale
+    let itemName: String
+
+    var body: some View {
+        List {
+            Section {
+                row(l10n.date, sale.date.toShortString())
+                if let price = sale.price {
+                    row(l10n.price, "$\(price, specifier: \"%.2f\")")
+                }
+                row(l10n.condition, sale.condition.label)
+                row(l10n.buyerName, sale.buyerName)
+                row(l10n.buyerContact, sale.buyerContact)
+                row(l10n.soldBy, sale.soldBy)
+                row(l10n.department, sale.department)
+            }
+        }
+        .navigationTitle(itemName)
+    }
+
+    @ViewBuilder
+    private func row(_ title: String, _ value: String) -> some View {
+        HStack {
+            Text(title).bold()
+            Spacer()
+            Text(value)
+        }
+    }
+}

--- a/RoomRoster/Views/SalesView.swift
+++ b/RoomRoster/Views/SalesView.swift
@@ -17,18 +17,20 @@ struct SalesView: View {
                         .foregroundColor(.secondary)
                 } else {
                     ForEach(Array(viewModel.sales.enumerated()), id: \.offset) { i, sale in
-                        VStack(alignment: .leading) {
-                            Text(sale.itemId)
-                                .font(.headline)
-                            HStack {
-                                Text(sale.date.toShortString())
-                                Spacer()
-                                if let price = sale.price {
-                                    Text("$\(price, specifier: "%.2f")")
+                        NavigationLink(destination: SalesDetailsView(sale: sale, itemName: viewModel.itemName(for: sale))) {
+                            VStack(alignment: .leading) {
+                                Text(viewModel.itemName(for: sale))
+                                    .font(.headline)
+                                HStack {
+                                    Text(sale.date.toShortString())
+                                    Spacer()
+                                    if let price = sale.price {
+                                        Text("$\(price, specifier: "%.2f")")
+                                    }
                                 }
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
                             }
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
                         }
                     }
                 }
@@ -36,6 +38,7 @@ struct SalesView: View {
             .navigationTitle(l10n.title)
         }
         .task { await viewModel.loadSales() }
+        .refreshable { await viewModel.loadSales() }
         .onAppear { Logger.page("SalesView") }
     }
 }


### PR DESCRIPTION
## Summary
- show item names in the Sales list instead of IDs
- enable drill down from Sales list to new `SalesDetailsView`
- support pull-to-refresh in Sales and Reports screens
- connect new view in Xcode project
- expose strings for sale details

## Testing
- `swiftc RoomRoster/Models/Sale.swift RoomRoster/Models/Condition.swift RoomRoster/Utilities/Extensions.swift RoomRoster/Views/SalesDetailsView.swift -parse-as-library` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_687820dbffe4832c98d7d717da5b9f4d