### PR TITLE
Show placeholder while loading sale items

### DIFF
--- a/RoomRoster/Utilities/Strings.swift
+++ b/RoomRoster/Utilities/Strings.swift
@@ -13,6 +13,7 @@ struct Strings {
         static let save = "Save"
         static let cancel = "Cancel"
         static let clear = "Clear"
+        static let loading = "Loading..."
     }
 
     // MARK: - MainMenu

--- a/RoomRoster/ViewModels/SalesViewModel.swift
+++ b/RoomRoster/ViewModels/SalesViewModel.swift
@@ -33,6 +33,6 @@ final class SalesViewModel: ObservableObject {
     }
 
     func itemName(for sale: Sale) -> String {
-        itemsById[sale.itemId]?.name ?? sale.itemId
+        itemsById[sale.itemId]?.name ?? Strings.general.loading
     }
 }


### PR DESCRIPTION
## Summary
- show a "Loading..." placeholder for sale items while item names are fetched
- add `loading` text in `Strings`

## Testing
- `xcodebuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68783152d50c832ca7122bd283f4ba6c