### PR TITLE
Improve sale workflow

### DIFF
--- a/RoomRoster.xcodeproj/project.pbxproj
+++ b/RoomRoster.xcodeproj/project.pbxproj
@@ -58,8 +58,9 @@
 		B6A6D6D62DD7AAEE00378BFF /* ItemField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A6D6D52DD7AAEE00378BFF /* ItemField.swift */; };
 		B6A6D6D82DD7AB3800378BFF /* FieldBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A6D6D72DD7AB3800378BFF /* FieldBinding.swift */; };
 		B6A6D6DA2DD84F5000378BFF /* EditItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A6D6D92DD84F5000378BFF /* EditItemViewModel.swift */; };
-		B6A6D6DC2DD8FD4E00378BFF /* ErrorBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A6D6DB2DD8FD4E00378BFF /* ErrorBanner.swift */; };
-		B6D80EF82E28255E00748907 /* ReceiptPDFGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D80EF72E28255E00748907 /* ReceiptPDFGenerator.swift */; };
+                B6A6D6DC2DD8FD4E00378BFF /* ErrorBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A6D6DB2DD8FD4E00378BFF /* ErrorBanner.swift */; };
+		AA12BBCC44D055EE00112233 /* SuccessBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA12BBCC44D055EE00112232 /* SuccessBanner.swift */; };
+                B6D80EF82E28255E00748907 /* ReceiptPDFGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D80EF72E28255E00748907 /* ReceiptPDFGenerator.swift */; };
 		B6D80EFA2E28259300748907 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = B6D80EF92E28259300748907 /* GoogleService-Info.plist */; };
 		B6E684CC2DCFB10400EE608B /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = B6E684CB2DCFB10400EE608B /* FirebaseCrashlytics */; };
 		B6E684D02DD03A6400EE608B /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = B6E684CF2DD03A6400EE608B /* Sentry */; };
@@ -153,9 +154,10 @@
 		B67560432DF0D231001A5D9D /* CreateItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateItemViewModel.swift; sourceTree = "<group>"; };
 		B6A6D6D52DD7AAEE00378BFF /* ItemField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemField.swift; sourceTree = "<group>"; };
 		B6A6D6D72DD7AB3800378BFF /* FieldBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldBinding.swift; sourceTree = "<group>"; };
-		B6A6D6D92DD84F5000378BFF /* EditItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditItemViewModel.swift; sourceTree = "<group>"; };
-		B6A6D6DB2DD8FD4E00378BFF /* ErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBanner.swift; sourceTree = "<group>"; };
-		B6D80EF72E28255E00748907 /* ReceiptPDFGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptPDFGenerator.swift; sourceTree = "<group>"; };
+                B6A6D6D92DD84F5000378BFF /* EditItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditItemViewModel.swift; sourceTree = "<group>"; };
+                B6A6D6DB2DD8FD4E00378BFF /* ErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBanner.swift; sourceTree = "<group>"; };
+		AA12BBCC44D055EE00112232 /* SuccessBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuccessBanner.swift; sourceTree = "<group>"; };
+                B6D80EF72E28255E00748907 /* ReceiptPDFGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptPDFGenerator.swift; sourceTree = "<group>"; };
 		B6D80EF92E28259300748907 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		B6E684D42DD176D900EE608B /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		B6F964912DB028E80093089A /* ImageUploadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadService.swift; sourceTree = "<group>"; };
@@ -357,8 +359,9 @@
 		B65F712E2DE64FBE00310D40 /* Components */ = {
 			isa = PBXGroup;
 			children = (
-				B6A6D6DB2DD8FD4E00378BFF /* ErrorBanner.swift */,
-				70EC0F7257914A11A7589F29 /* ShareSheet.swift */,
+                               B6A6D6DB2DD8FD4E00378BFF /* ErrorBanner.swift */,
+				AA12BBCC44D055EE00112232 /* SuccessBanner.swift */,
+                                70EC0F7257914A11A7589F29 /* ShareSheet.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -525,8 +528,9 @@
 				B615ED222DE2BB4E009BE623 /* RoomService.swift in Sources */,
 				767E82C92D8F1AA500B48011 /* NetworkService.swift in Sources */,
 				767B05BF2D4C5F9E00566C25 /* GoogleSheetsResponse.swift in Sources */,
-				B6A6D6DC2DD8FD4E00378BFF /* ErrorBanner.swift in Sources */,
-				B6A6D6DA2DD84F5000378BFF /* EditItemViewModel.swift in Sources */,
+                                B6A6D6DC2DD8FD4E00378BFF /* ErrorBanner.swift in Sources */,
+				AA12BBCC44D055EE00112233 /* SuccessBanner.swift in Sources */,
+                                B6A6D6DA2DD84F5000378BFF /* EditItemViewModel.swift in Sources */,
 				B615ED1C2DE12A16009BE623 /* Status.swift in Sources */,
 				B6A6D6D82DD7AB3800378BFF /* FieldBinding.swift in Sources */,
 				767E82D32D8F34C800B48011 /* Extensions.swift in Sources */,

--- a/RoomRoster/Services/GmailService.swift
+++ b/RoomRoster/Services/GmailService.swift
@@ -35,6 +35,7 @@ struct GmailService {
             method: "POST",
             jsonBody: ["raw": encoded]
         )
+        Logger.network("GmailService-sendEmail")
         try await networkService.sendRequest(request)
     }
 }

--- a/RoomRoster/Services/SalesService.swift
+++ b/RoomRoster/Services/SalesService.swift
@@ -30,6 +30,12 @@ actor SalesService {
         try await networkService.sendRequest(request)
     }
 
+    func fetchSale(for itemId: String) async throws -> Sale? {
+        Logger.network("SalesService-fetchSale")
+        let sales = try await fetchSales()
+        return sales.first { $0.itemId == itemId }
+    }
+
     func fetchSales() async throws -> [Sale] {
         let url = "https://sheets.googleapis.com/v4/spreadsheets/\(sheetId)/values/Sales?key=\(apiKey)"
         Logger.network("SalesService-fetchSales")

--- a/RoomRoster/Utilities/Strings.swift
+++ b/RoomRoster/Utilities/Strings.swift
@@ -258,6 +258,8 @@ struct Strings {
         static let sellerSection = "Seller"
         static let soldBy = "Sold By"
         static let department = "Department"
+        static let success = "Sale recorded successfully"
+        static let failure = "Failed to record sale. Please try again."
     }
 
     // MARK: - SaleDetailsView

--- a/RoomRoster/Views/Components/SuccessBanner.swift
+++ b/RoomRoster/Views/Components/SuccessBanner.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct SuccessBanner: View {
+    let message: String
+
+    var body: some View {
+        Text(message)
+            .font(.subheadline)
+            .padding()
+            .frame(maxWidth: .infinity)
+            .background(Color.green.opacity(0.9))
+            .foregroundColor(.white)
+            .cornerRadius(8)
+            .padding(.horizontal)
+            .transition(.move(edge: .top).combined(with: .opacity))
+            .animation(.easeInOut, value: message)
+    }
+}

--- a/RoomRoster/Views/InventoryView.swift
+++ b/RoomRoster/Views/InventoryView.swift
@@ -55,7 +55,7 @@ struct InventoryView: View {
                         Section(header: sectionHeader(for: group.room)) {
                             if expandedRooms.contains(group.room) {
                                 ForEach(group.items, id: \.0.id) { (item, context) in
-                                    NavigationLink(destination: ItemDetailsView(item: item)) {
+                                    NavigationLink(destination: ItemDetailsView(item: item).environmentObject(viewModel)) {
                                         VStack(alignment: .leading) {
                                             Text(item.name).font(.headline)
                                             Text(l10n.status(item.status.label))

--- a/RoomRoster/Views/SellItemView.swift
+++ b/RoomRoster/Views/SellItemView.swift
@@ -5,6 +5,7 @@ private typealias l10n = Strings.sellItem
 struct SellItemView: View {
     @Environment(\.dismiss) var dismiss
     @StateObject var viewModel: SellItemViewModel
+    var onComplete: (Result<Item, Error>) -> Void
 
     var body: some View {
         NavigationView {
@@ -33,13 +34,16 @@ struct SellItemView: View {
                 Button(Strings.general.save) {
                     Task {
                         do {
-                            try await viewModel.submitSale()
+                            let item = try await viewModel.submitSale()
+                            onComplete(.success(item))
                             dismiss()
                         } catch {
                             Logger.log(error, extra: ["description": "Failed to record sale"])
+                            onComplete(.failure(error))
                         }
                     }
                 }
+                .disabled(viewModel.isSubmitting)
             }
             .navigationTitle(l10n.title)
             .toolbar {
@@ -50,3 +54,4 @@ struct SellItemView: View {
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- show success banner component
- add sale success messages
- support sale details and sale refresh in ItemDetailsView
- prevent duplicate submissions and return updated item
- pass InventoryViewModel to ItemDetailsView
- log Gmail activity and fetch individual sales

## Testing
- `swift --version`
- `xcodebuild test -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878305f2e78832ca21c6f4725d01509