### PR TITLE
Add Secrets-Example.plist sample

### DIFF
--- a/RoomRoster/Secrets-Example.plist
+++ b/RoomRoster/Secrets-Example.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>SheetID</key>
+    <string>YOUR_SHEET_ID</string>
+    <key>GoogleSheetsAPIKey</key>
+    <string>YOUR_GOOGLE_SHEETS_API_KEY</string>
+    <key>SentryDSN</key>
+    <string>YOUR_SENTRY_DSN</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add `Secrets-Example.plist` with placeholder values
- reference the example plist in the README
- keep the example plist out of the Xcode project

## Testing
- `swift --version`
- `xcodebuild -list -project RoomRoster.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687830eb2c54832cbd6abd5bc9e4c734