### PR TITLE
Remove outdated 'Coming Soon' strings

### DIFF
--- a/RoomRoster/Utilities/Strings.swift
+++ b/RoomRoster/Utilities/Strings.swift
@@ -235,7 +235,6 @@ struct Strings {
     // MARK: - SheetsView
     struct sheets {
         static let title = "Sheets"
-        static let comingSoon = "Sheets - Coming Soon"
         static let signInPrompt = "Sign in to view sheets"
         static let signInButton = "Sign In"
     }
@@ -243,7 +242,6 @@ struct Strings {
     // MARK: - SalesView
     struct sales {
         static let title = "Sales"
-        static let comingSoon = "Sales - Coming Soon"
         static let emptyState = "No sales recorded"
         static let failedToLoad = "Failed to load sales. Please try again."
     }


### PR DESCRIPTION
## Summary
- clean up Strings.swift by removing unused "Coming Soon" constants for Sheets and Sales views

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68792c21b564832cb87bfdfe86e929f3