### PR TITLE
Add chart-based visual reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ RoomRoster is a SwiftUI-based inventory management application that integrates w
 - **History Logs:** Fetches and displays the history log for each item from a dedicated Google Sheets range.
 - **Edit Functionality:** Allows users to edit item details via a dedicated editing view.
 - **Sales Tracking:** Record item sales with buyer information and condition while emailing receipts.
+- **Visual Reports:** Inventory and sales reports display bar and pie charts powered by Apple's Charts framework.
 - **Modern Concurrency:** Utilizes Swift's async/await for cleaner and more efficient asynchronous networking.
 - **Clean Architecture:** Implements a clear separation of concerns with dedicated networking and service layers, view models, and SwiftUI views.
 

--- a/RoomRoster/ViewModels/ReportsViewModel.swift
+++ b/RoomRoster/ViewModels/ReportsViewModel.swift
@@ -109,6 +109,18 @@ final class ReportsViewModel: ObservableObject {
         }
     }
 
+    var salesByMonth: [(date: Date, total: Double)] {
+        let calendar = Calendar.current
+        let groups = Dictionary(grouping: sales) { sale in
+            calendar.date(from: calendar.dateComponents([.year, .month], from: sale.date)) ?? sale.date
+        }
+        return groups.map { key, values in
+            let total = values.compactMap { $0.price }.reduce(0, +)
+            return (key, total)
+        }
+        .sorted { $0.date < $1.date }
+    }
+
     func exportCSV() -> URL? {
         let header = ItemField.allCases.map { $0.label }.joined(separator: ",")
         let lines: [String] = filteredItems.map { item in

--- a/RoomRoster/Views/ReportsView.swift
+++ b/RoomRoster/Views/ReportsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Charts
 
 private typealias l10n = Strings.reports
 
@@ -37,6 +38,15 @@ struct ReportsView: View {
                 }
 
                 Section(header: Text(l10n.inventorySummary)) {
+                    Chart {
+                        ForEach(Status.allCases, id: \.self) { status in
+                            let count = viewModel.statusCounts[status] ?? 0
+                            SectorMark(angle: .value("Count", count))
+                                .foregroundStyle(by: .value("Status", status.label))
+                        }
+                    }
+                    .frame(height: 180)
+
                     ForEach(Status.allCases, id: \.self) { status in
                         HStack {
                             Text(status.label)
@@ -52,6 +62,16 @@ struct ReportsView: View {
                 }
 
                 Section(header: Text(l10n.salesOverview)) {
+                    Chart {
+                        ForEach(viewModel.salesByMonth, id: \.date) { entry in
+                            BarMark(
+                                x: .value("Month", entry.date),
+                                y: .value("Revenue", entry.total)
+                            )
+                        }
+                    }
+                    .frame(height: 180)
+
                     HStack {
                         Text(l10n.totalSold)
                         Spacer()
@@ -65,6 +85,16 @@ struct ReportsView: View {
                 }
 
                 Section(header: Text(l10n.roomsSummary)) {
+                    Chart {
+                        ForEach(viewModel.roomCounts.keys.sorted(by: { $0.label < $1.label }), id: \.self) { room in
+                            BarMark(
+                                x: .value("Room", room.label),
+                                y: .value("Items", viewModel.roomCounts[room] ?? 0)
+                            )
+                        }
+                    }
+                    .frame(height: 180)
+
                     ForEach(viewModel.roomCounts.keys.sorted(by: { $0.label < $1.label }), id: \.self) { room in
                         HStack {
                             Text(room.label)


### PR DESCRIPTION
## Summary
- visualize inventory data with Apple's Charts framework
- chart inventory by status, items by room, and monthly sales metrics
- document visual reports feature in README

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68792c1d9214832c997e6686183b69dc