### PR TITLE
Add local caching for inventory using CoreData

### DIFF
--- a/RoomRoster.xcodeproj/project.pbxproj
+++ b/RoomRoster.xcodeproj/project.pbxproj
@@ -66,8 +66,10 @@
 		B6D80EFA2E28259300748907 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = B6D80EF92E28259300748907 /* GoogleService-Info.plist */; };
 		B6D80EFB2E28CF5800748907 /* Spreadsheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9022FF3CD87CA507378085C4 /* Spreadsheet.swift */; };
 		B6D80EFD2E28DD8D00748907 /* SpreadsheetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D80EFC2E28DD8D00748907 /* SpreadsheetManager.swift */; };
-		B6D80EFE2E295A1600748907 /* HapticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77809C47FCD59CC9A4E795CC /* HapticManager.swift */; };
-		B6E684CC2DCFB10400EE608B /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = B6E684CB2DCFB10400EE608B /* FirebaseCrashlytics */; };
+                B6D80EFE2E295A1600748907 /* HapticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77809C47FCD59CC9A4E795CC /* HapticManager.swift */; };
+                E9E2624232BE6EB5EE77CAE2 /* PersistenceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621BCB52E73E50E2D3DE5AB4 /* PersistenceController.swift */; };
+                4DF63AAA378D62CD8D5C914C /* InventoryCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25826F1B01528D669EE8A64A /* InventoryCache.swift */; };
+                B6E684CC2DCFB10400EE608B /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = B6E684CB2DCFB10400EE608B /* FirebaseCrashlytics */; };
 		B6E684D02DD03A6400EE608B /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = B6E684CF2DD03A6400EE608B /* Sentry */; };
 		B6E684D32DD03D2400EE608B /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = B6E684D22DD03D2400EE608B /* FirebaseStorage */; };
 		B6E684D52DD176DA00EE608B /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E684D42DD176D900EE608B /* Logger.swift */; };
@@ -139,8 +141,10 @@
 		767E82D42D8F356500B48011 /* EditItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditItemView.swift; sourceTree = "<group>"; };
 		767E82D62D8F3ABE00B48011 /* AuthenticationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationManager.swift; sourceTree = "<group>"; };
 		767E82DF2D8F52FF00B48011 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		77809C47FCD59CC9A4E795CC /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
-		8BC8C5F5D40748AD93602E33 /* SalesServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesServiceTests.swift; sourceTree = "<group>"; };
+                77809C47FCD59CC9A4E795CC /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
+                621BCB52E73E50E2D3DE5AB4 /* PersistenceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceController.swift; sourceTree = "<group>"; };
+                25826F1B01528D669EE8A64A /* InventoryCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InventoryCache.swift; sourceTree = "<group>"; };
+                8BC8C5F5D40748AD93602E33 /* SalesServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesServiceTests.swift; sourceTree = "<group>"; };
 		9022FF3CD87CA507378085C4 /* Spreadsheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spreadsheet.swift; sourceTree = "<group>"; };
 		9062D441F4874BA89C2A0A1E /* InventoryServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InventoryServiceTests.swift; sourceTree = "<group>"; };
 		A4280063F1BA4122A570E8B9 /* InventoryUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InventoryUITests.swift; sourceTree = "<group>"; };
@@ -315,8 +319,9 @@
 				765183BC2D8CD25300FBA72E /* Services */,
 				765183BA2D8CD20800FBA72E /* ViewModels */,
 				765183B92D8CD1F300FBA72E /* Views */,
-				767E82D12D8F34B900B48011 /* Utilities */,
-				767B05952D4C5DC400566C25 /* Assets.xcassets */,
+                                767E82D12D8F34B900B48011 /* Utilities */,
+                                2E7F718FE75B8645F89D37EF /* Persistence */,
+                                767B05952D4C5DC400566C25 /* Assets.xcassets */,
 				767B05972D4C5DC400566C25 /* RoomRoster.entitlements */,
 				767B05982D4C5DC400566C25 /* Preview Content */,
 			);
@@ -357,22 +362,31 @@
 			path = RoomRosterUITests;
 			sourceTree = "<group>";
 		};
-		767E82D12D8F34B900B48011 /* Utilities */ = {
-			isa = PBXGroup;
-			children = (
-				B6D80EFC2E28DD8D00748907 /* SpreadsheetManager.swift */,
-				B65F712F2DEB5C4D00310D40 /* ItemValidator.swift */,
-				B65F712C2DE64F8500310D40 /* Strings.swift */,
-				767E82D62D8F3ABE00B48011 /* AuthenticationManager.swift */,
-				767E82D22D8F34C800B48011 /* Extensions.swift */,
-				B6E684D42DD176D900EE608B /* Logger.swift */,
-				77809C47FCD59CC9A4E795CC /* HapticManager.swift */,
-				B61A9BD72DD6650000D04E9A /* SheetsUtils.swift */,
-			);
-			path = Utilities;
-			sourceTree = "<group>";
-		};
-		B65F712E2DE64FBE00310D40 /* Components */ = {
+                767E82D12D8F34B900B48011 /* Utilities */ = {
+                        isa = PBXGroup;
+                        children = (
+                                B6D80EFC2E28DD8D00748907 /* SpreadsheetManager.swift */,
+                                B65F712F2DEB5C4D00310D40 /* ItemValidator.swift */,
+                                B65F712C2DE64F8500310D40 /* Strings.swift */,
+                                767E82D62D8F3ABE00B48011 /* AuthenticationManager.swift */,
+                                767E82D22D8F34C800B48011 /* Extensions.swift */,
+                                B6E684D42DD176D900EE608B /* Logger.swift */,
+                                77809C47FCD59CC9A4E795CC /* HapticManager.swift */,
+                                B61A9BD72DD6650000D04E9A /* SheetsUtils.swift */,
+                        );
+                        path = Utilities;
+                        sourceTree = "<group>";
+                };
+                2E7F718FE75B8645F89D37EF /* Persistence */ = {
+                        isa = PBXGroup;
+                        children = (
+                                621BCB52E73E50E2D3DE5AB4 /* PersistenceController.swift */,
+                                25826F1B01528D669EE8A64A /* InventoryCache.swift */,
+                        );
+                        path = Persistence;
+                        sourceTree = "<group>";
+                };
+                B65F712E2DE64FBE00310D40 /* Components */ = {
 			isa = PBXGroup;
 			children = (
 				B6A6D6DB2DD8FD4E00378BFF /* ErrorBanner.swift */,
@@ -545,8 +559,10 @@
 				B6D80EFD2E28DD8D00748907 /* SpreadsheetManager.swift in Sources */,
 				B615ED222DE2BB4E009BE623 /* RoomService.swift in Sources */,
 				767E82C92D8F1AA500B48011 /* NetworkService.swift in Sources */,
-				B6D80EFE2E295A1600748907 /* HapticManager.swift in Sources */,
-				767B05BF2D4C5F9E00566C25 /* GoogleSheetsResponse.swift in Sources */,
+                                B6D80EFE2E295A1600748907 /* HapticManager.swift in Sources */,
+                                E9E2624232BE6EB5EE77CAE2 /* PersistenceController.swift in Sources */,
+                                4DF63AAA378D62CD8D5C914C /* InventoryCache.swift in Sources */,
+                                767B05BF2D4C5F9E00566C25 /* GoogleSheetsResponse.swift in Sources */,
 				B6A6D6DC2DD8FD4E00378BFF /* ErrorBanner.swift in Sources */,
 				AA12BBCC44D055EE00112233 /* SuccessBanner.swift in Sources */,
 				B6A6D6DA2DD84F5000378BFF /* EditItemViewModel.swift in Sources */,

--- a/RoomRoster/Models/Item.swift
+++ b/RoomRoster/Models/Item.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Item: Identifiable {
+struct Item: Identifiable, Codable {
     var id: String
     var imageURL: String
     var name: String

--- a/RoomRoster/Persistence/InventoryCache.swift
+++ b/RoomRoster/Persistence/InventoryCache.swift
@@ -1,0 +1,46 @@
+import Foundation
+import CoreData
+
+actor InventoryCache {
+    static let shared = InventoryCache()
+    private let container = PersistenceController.shared.container
+
+    func fetchItems() -> [Item] {
+        let context = container.viewContext
+        let request: NSFetchRequest<CachedItem> = CachedItem.fetchRequest()
+        let results = (try? context.fetch(request)) ?? []
+        return results.compactMap { try? JSONDecoder().decode(Item.self, from: $0.data) }
+    }
+
+    func fetchItem(id: String) -> Item? {
+        let context = container.viewContext
+        let request: NSFetchRequest<CachedItem> = CachedItem.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", id)
+        request.fetchLimit = 1
+        guard let cached = try? context.fetch(request).first else { return nil }
+        return try? JSONDecoder().decode(Item.self, from: cached.data)
+    }
+
+    func save(items: [Item]) {
+        let context = container.viewContext
+        let request: NSFetchRequest<NSFetchRequestResult> = CachedItem.fetchRequest()
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: request)
+        _ = try? context.execute(deleteRequest)
+        for item in items {
+            let cached = CachedItem(context: context)
+            cached.id = item.id
+            cached.data = (try? JSONEncoder().encode(item)) ?? Data()
+        }
+        try? context.save()
+    }
+
+    func upsert(_ item: Item) {
+        let context = container.viewContext
+        let request: NSFetchRequest<CachedItem> = CachedItem.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", item.id)
+        let cached = (try? context.fetch(request).first) ?? CachedItem(context: context)
+        cached.id = item.id
+        cached.data = (try? JSONEncoder().encode(item)) ?? Data()
+        try? context.save()
+    }
+}

--- a/RoomRoster/Persistence/PersistenceController.swift
+++ b/RoomRoster/Persistence/PersistenceController.swift
@@ -1,0 +1,54 @@
+import Foundation
+import CoreData
+
+final class CachedItem: NSManagedObject {
+    @NSManaged var id: String
+    @NSManaged var data: Data
+}
+
+struct PersistenceController {
+    static let shared = PersistenceController()
+
+    let container: NSPersistentContainer
+
+    init(inMemory: Bool = false) {
+        let model = Self.managedObjectModel
+        container = NSPersistentContainer(name: "RoomRosterModel", managedObjectModel: model)
+        if inMemory {
+            container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
+        }
+        container.loadPersistentStores { _, error in
+            if let error {
+                fatalError("Unresolved error \(error)")
+            }
+        }
+        container.viewContext.automaticallyMergesChangesFromParent = true
+    }
+
+    private static var managedObjectModel: NSManagedObjectModel {
+        let model = NSManagedObjectModel()
+        let entity = NSEntityDescription()
+        entity.name = "CachedItem"
+        entity.managedObjectClassName = NSStringFromClass(CachedItem.self)
+
+        let idAttr = NSAttributeDescription()
+        idAttr.name = "id"
+        idAttr.attributeType = .stringAttributeType
+        idAttr.isOptional = false
+
+        let dataAttr = NSAttributeDescription()
+        dataAttr.name = "data"
+        dataAttr.attributeType = .binaryDataAttributeType
+        dataAttr.isOptional = false
+
+        entity.properties = [idAttr, dataAttr]
+        model.entities = [entity]
+        return model
+    }
+}
+
+extension CachedItem {
+    @nonobjc class func fetchRequest() -> NSFetchRequest<CachedItem> {
+        NSFetchRequest<CachedItem>(entityName: "CachedItem")
+    }
+}


### PR DESCRIPTION
## Summary
- conform `Item` to `Codable`
- create `PersistenceController` and `InventoryCache` for CoreData storage
- store fetched items locally and allow retrieval from cache
- update Xcode project to include new persistence files

## Testing
- `swift --version`
- `xcodebuild -list -project RoomRoster.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68792c025ee4832c97e80c211a867341