### PR TITLE
Add loading indicator & refresh after sign‑in

### DIFF
--- a/RoomRoster/Utilities/SpreadsheetManager.swift
+++ b/RoomRoster/Utilities/SpreadsheetManager.swift
@@ -14,6 +14,7 @@ final class SpreadsheetManager: ObservableObject {
 
     @Published private(set) var spreadsheets: [Spreadsheet] = []
     @Published var currentSheet: Spreadsheet?
+    @Published private(set) var isLoading: Bool = false
 
     private let networkService: NetworkServiceProtocol
     private init(networkService: NetworkServiceProtocol = NetworkService.shared) {
@@ -26,6 +27,8 @@ final class SpreadsheetManager: ObservableObject {
 
     func loadSheets() async {
         guard AuthenticationManager.shared.isSignedIn else { return }
+        isLoading = true
+        defer { isLoading = false }
         do {
             let driveURL = URL(string: "https://www.googleapis.com/drive/v3/files?q=mimeType='application/vnd.google-apps.spreadsheet'&fields=files(id,name)")!
             let list: DriveFilesResponse = try await networkService.fetchAuthorizedData(from: driveURL)

--- a/RoomRoster/Utilities/Strings.swift
+++ b/RoomRoster/Utilities/Strings.swift
@@ -238,6 +238,7 @@ struct Strings {
         static let comingSoon = "Sheets - Coming Soon"
         static let signInPrompt = "Sign in to view sheets"
         static let signInButton = "Sign In"
+        static let loading = "Loading Sheets..."
     }
 
     // MARK: - SalesView

--- a/RoomRoster/Views/SheetsView.swift
+++ b/RoomRoster/Views/SheetsView.swift
@@ -16,18 +16,23 @@ struct SheetsView: View {
     var body: some View {
         Group {
             if auth.isSignedIn {
-                List {
-                    ForEach(manager.spreadsheets) { sheet in
-                        HStack {
-                            Text(sheet.name)
-                            Spacer()
-                            if sheet.id == manager.currentSheet?.id {
-                                Image(systemName: "checkmark")
-                                    .foregroundColor(.accentColor)
+                if manager.isLoading {
+                    ProgressView(l10n.loading)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    List {
+                        ForEach(manager.spreadsheets) { sheet in
+                            HStack {
+                                Text(sheet.name)
+                                Spacer()
+                                if sheet.id == manager.currentSheet?.id {
+                                    Image(systemName: "checkmark")
+                                        .foregroundColor(.accentColor)
+                                }
                             }
+                            .contentShape(Rectangle())
+                            .onTapGesture { manager.select(sheet) }
                         }
-                        .contentShape(Rectangle())
-                        .onTapGesture { manager.select(sheet) }
                     }
                 }
             } else {
@@ -44,6 +49,11 @@ struct SheetsView: View {
         .onAppear {
             Logger.page("SheetsView")
             Task { await manager.loadSheets() }
+        }
+        .onChange(of: auth.isSignedIn) { _, signedIn in
+            if signedIn {
+                Task { await manager.loadSheets() }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- show a loading indicator while fetching sheet list
- keep track of loading state in `SpreadsheetManager`
- load sheets again when sign‑in completes
- add string for loading message

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68792fd1827c832c946281ef0be512fc