### PR TITLE
Fix sign-in popup disappearing

### DIFF
--- a/RoomRoster/Views/ItemDetailsView.swift
+++ b/RoomRoster/Views/ItemDetailsView.swift
@@ -227,8 +227,8 @@ struct ItemDetailsView: View {
         .onAppear {
             Logger.page("ItemDetailsView")
         }
-        .task {
-            await AuthenticationManager.shared.signIn()
+        .onAppear {
+            Task { await AuthenticationManager.shared.signIn() }
         }
         .task {
             await viewModel.fetchItemHistory(for: item.id)

--- a/RoomRoster/Views/MainMenuView.swift
+++ b/RoomRoster/Views/MainMenuView.swift
@@ -48,6 +48,8 @@ struct MainMenuView: View {
         .onChange(of: selectedTab) { _, _ in
             HapticManager.shared.impact()
         }
-        .task { await auth.signIn() }
+        .onAppear {
+            Task { await auth.signIn() }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure the sign-in task isn't cancelled by view updates
- call sign-in from `onAppear` in `MainMenuView` and `ItemDetailsView`

## Testing
- `swift --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68792f828b90832ca18830b03853b8fb