### PR TITLE
Add prompt when no sheet selected

### DIFF
--- a/RoomRoster/Utilities/Strings.swift
+++ b/RoomRoster/Utilities/Strings.swift
@@ -45,6 +45,8 @@ struct Strings {
         static let failedToLoadRooms = "Failed to load rooms. Please try again."
         static let failedToAddRoom = "Failed to add room. Please try again."
         static let failedToLoadLogs = "Failed to load logs. Please try again."
+        static let emptyState = "No items to display"
+        static let selectSheetPrompt = "Select a sheet in the Sheets tab"
         struct query {
             static let name = "name"
             static let description = "description"

--- a/RoomRoster/Views/SalesView.swift
+++ b/RoomRoster/Views/SalesView.swift
@@ -4,6 +4,7 @@ private typealias l10n = Strings.sales
 
 struct SalesView: View {
     @StateObject private var viewModel = SalesViewModel()
+    @StateObject private var sheets = SpreadsheetManager.shared
 
     var body: some View {
         NavigationView {
@@ -12,7 +13,10 @@ struct SalesView: View {
                     ErrorBanner(message: error)
                 }
 
-                if viewModel.sales.isEmpty {
+                if sheets.currentSheet == nil {
+                    Text(Strings.inventory.selectSheetPrompt)
+                        .foregroundColor(.secondary)
+                } else if viewModel.sales.isEmpty {
                     Text(l10n.emptyState)
                         .foregroundColor(.secondary)
                 } else {
@@ -40,8 +44,14 @@ struct SalesView: View {
             }
             .navigationTitle(l10n.title)
         }
-        .task { await viewModel.loadSales() }
-        .refreshable { await viewModel.loadSales() }
+        .task {
+            guard sheets.currentSheet != nil else { return }
+            await viewModel.loadSales()
+        }
+        .refreshable {
+            guard sheets.currentSheet != nil else { return }
+            await viewModel.loadSales()
+        }
         .onAppear { Logger.page("SalesView") }
     }
 }


### PR DESCRIPTION
## Summary
- add select-sheet prompt and inventory empty state strings
- show prompt in InventoryView, SalesView, and ReportsView when no sheet selected
- guard data loading tasks behind sheet selection

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6879425e2b38832c95950fded9e09442