### PR TITLE
Handle unauthorized errors with re-signin

### DIFF
--- a/RoomRoster/ViewModels/SalesViewModel.swift
+++ b/RoomRoster/ViewModels/SalesViewModel.swift
@@ -18,6 +18,7 @@ final class SalesViewModel: ObservableObject {
     }
 
     func loadSales() async {
+        errorMessage = nil
         do {
             itemsById = [:]
             sales = try await salesService.fetchSales()


### PR DESCRIPTION
## Summary
- add silent re-authentication helper methods and an `ensureSignedIn()` convenience
- ensure network requests call `ensureSignedIn()` and retry on 401
- reset `errorMessage` when loading sales so banner clears after re-auth

## Testing
- `swift test -v` *(fails: Package.swift not found)*
- `xcodebuild -list -project RoomRoster.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68794f45e808832c8f4ba366e2046331