### PR TITLE
Implement depreciation calculator

### DIFF
--- a/RoomRoster.xcodeproj/project.pbxproj
+++ b/RoomRoster.xcodeproj/project.pbxproj
@@ -66,8 +66,9 @@
 		B6D80EFA2E28259300748907 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = B6D80EF92E28259300748907 /* GoogleService-Info.plist */; };
 		B6D80EFB2E28CF5800748907 /* Spreadsheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9022FF3CD87CA507378085C4 /* Spreadsheet.swift */; };
 		B6D80EFD2E28DD8D00748907 /* SpreadsheetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D80EFC2E28DD8D00748907 /* SpreadsheetManager.swift */; };
-		B6D80EFE2E295A1600748907 /* HapticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77809C47FCD59CC9A4E795CC /* HapticManager.swift */; };
-		B6E684CC2DCFB10400EE608B /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = B6E684CB2DCFB10400EE608B /* FirebaseCrashlytics */; };
+                B6D80EFE2E295A1600748907 /* HapticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77809C47FCD59CC9A4E795CC /* HapticManager.swift */; };
+		0A2B89787187428E8B76DD58 /* DepreciationCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A63CDB2EA6A42EA93C1D13D /* DepreciationCalculator.swift */; };
+                B6E684CC2DCFB10400EE608B /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = B6E684CB2DCFB10400EE608B /* FirebaseCrashlytics */; };
 		B6E684D02DD03A6400EE608B /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = B6E684CF2DD03A6400EE608B /* Sentry */; };
 		B6E684D32DD03D2400EE608B /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = B6E684D22DD03D2400EE608B /* FirebaseStorage */; };
 		B6E684D52DD176DA00EE608B /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E684D42DD176D900EE608B /* Logger.swift */; };
@@ -80,8 +81,9 @@
 		B6F9649F2DB02BB60093089A /* FirebaseAppDistribution-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = B6F9649E2DB02BB60093089A /* FirebaseAppDistribution-Beta */; };
 		B6F964A12DB02C470093089A /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = B6F964A02DB02C470093089A /* FirebaseAuth */; };
 		B6F964A32DB02C470093089A /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = B6F964A22DB02C470093089A /* FirebaseStorage */; };
-		B7F2B3A12FF645E8A0FF1234 /* SheetsUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F2B3A12FF645E8A0FF1235 /* SheetsUtilsTests.swift */; };
-		C616CDE1A2B34C5D67890ABE /* SalesDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C616CDE1A2B34C5D67890ABD /* SalesDetailsView.swift */; };
+                B7F2B3A12FF645E8A0FF1234 /* SheetsUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F2B3A12FF645E8A0FF1235 /* SheetsUtilsTests.swift */; };
+		7B030D6795A8463589912FAE /* DepreciationCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2ACBFBB75EA4E3C9514A9AB /* DepreciationCalculatorTests.swift */; };
+                C616CDE1A2B34C5D67890ABE /* SalesDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C616CDE1A2B34C5D67890ABD /* SalesDetailsView.swift */; };
 		CE2487F2AA23494BBE56993D /* ReportsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12FE82B0693248D49E8D77BB /* ReportsViewModel.swift */; };
 		DE7D257232324BDDB96C6F37 /* RoomServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614508236AFA4269887FF35A /* RoomServiceTests.swift */; };
 		E9FBF450607D494DA1894333 /* MockNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF137618CD644A1997B55ED6 /* MockNetworkService.swift */; };
@@ -139,8 +141,9 @@
 		767E82D42D8F356500B48011 /* EditItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditItemView.swift; sourceTree = "<group>"; };
 		767E82D62D8F3ABE00B48011 /* AuthenticationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationManager.swift; sourceTree = "<group>"; };
 		767E82DF2D8F52FF00B48011 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		77809C47FCD59CC9A4E795CC /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
-		8BC8C5F5D40748AD93602E33 /* SalesServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesServiceTests.swift; sourceTree = "<group>"; };
+                77809C47FCD59CC9A4E795CC /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
+		8A63CDB2EA6A42EA93C1D13D /* DepreciationCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepreciationCalculator.swift; sourceTree = "<group>"; };
+                8BC8C5F5D40748AD93602E33 /* SalesServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesServiceTests.swift; sourceTree = "<group>"; };
 		9022FF3CD87CA507378085C4 /* Spreadsheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spreadsheet.swift; sourceTree = "<group>"; };
 		9062D441F4874BA89C2A0A1E /* InventoryServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InventoryServiceTests.swift; sourceTree = "<group>"; };
 		A4280063F1BA4122A570E8B9 /* InventoryUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InventoryUITests.swift; sourceTree = "<group>"; };
@@ -177,7 +180,8 @@
 		D635C54A7B58948D1F8036B4 /* SpreadsheetManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpreadsheetManagerTests.swift; sourceTree = "<group>"; };
 		E32FE1D99B3B44E6A6801234 /* SalesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesViewModel.swift; sourceTree = "<group>"; };
 		E71B5019D5A040FCBB81807B /* ItemValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemValidatorTests.swift; sourceTree = "<group>"; };
-		F1DB1AD2C44D425AB9A59153 /* SellItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellItemViewModel.swift; sourceTree = "<group>"; };
+                F1DB1AD2C44D425AB9A59153 /* SellItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellItemViewModel.swift; sourceTree = "<group>"; };
+		F2ACBFBB75EA4E3C9514A9AB /* DepreciationCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepreciationCalculatorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -343,10 +347,11 @@
 				8BC8C5F5D40748AD93602E33 /* SalesServiceTests.swift */,
 				D635C54A7B58948D1F8036B4 /* SpreadsheetManagerTests.swift */,
 				B7F2B3A12FF645E8A0FF1235 /* SheetsUtilsTests.swift */,
-			);
-			path = RoomRosterTests;
-			sourceTree = "<group>";
-		};
+				F2ACBFBB75EA4E3C9514A9AB /* DepreciationCalculatorTests.swift */,
+                        );
+                        path = RoomRosterTests;
+                        sourceTree = "<group>";
+                };
 		767B05AC2D4C5DC400566C25 /* RoomRosterUITests */ = {
 			isa = PBXGroup;
 			children = (
@@ -367,11 +372,12 @@
 				767E82D22D8F34C800B48011 /* Extensions.swift */,
 				B6E684D42DD176D900EE608B /* Logger.swift */,
 				77809C47FCD59CC9A4E795CC /* HapticManager.swift */,
+				8A63CDB2EA6A42EA93C1D13D /* DepreciationCalculator.swift */,
 				B61A9BD72DD6650000D04E9A /* SheetsUtils.swift */,
-			);
-			path = Utilities;
-			sourceTree = "<group>";
-		};
+                        );
+                        path = Utilities;
+                        sourceTree = "<group>";
+                };
 		B65F712E2DE64FBE00310D40 /* Components */ = {
 			isa = PBXGroup;
 			children = (
@@ -546,7 +552,8 @@
 				B615ED222DE2BB4E009BE623 /* RoomService.swift in Sources */,
 				767E82C92D8F1AA500B48011 /* NetworkService.swift in Sources */,
 				B6D80EFE2E295A1600748907 /* HapticManager.swift in Sources */,
-				767B05BF2D4C5F9E00566C25 /* GoogleSheetsResponse.swift in Sources */,
+				0A2B89787187428E8B76DD58 /* DepreciationCalculator.swift in Sources */,
+                               767B05BF2D4C5F9E00566C25 /* GoogleSheetsResponse.swift in Sources */,
 				B6A6D6DC2DD8FD4E00378BFF /* ErrorBanner.swift in Sources */,
 				AA12BBCC44D055EE00112233 /* SuccessBanner.swift in Sources */,
 				B6A6D6DA2DD84F5000378BFF /* EditItemViewModel.swift in Sources */,
@@ -588,9 +595,10 @@
 				630A8C62F5BBC9555EEC2E18 /* SpreadsheetManagerTests.swift in Sources */,
 				B7F2B3A12FF645E8A0FF1234 /* SheetsUtilsTests.swift in Sources */,
 				B7F2B3A12FF645E8A0FF1234 /* SheetsUtilsTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+				7B030D6795A8463589912FAE /* DepreciationCalculatorTests.swift in Sources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 		767B05A52D4C5DC400566C25 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;

--- a/RoomRoster.xcodeproj/project.pbxproj
+++ b/RoomRoster.xcodeproj/project.pbxproj
@@ -553,7 +553,7 @@
 				767E82C92D8F1AA500B48011 /* NetworkService.swift in Sources */,
 				B6D80EFE2E295A1600748907 /* HapticManager.swift in Sources */,
 				0A2B89787187428E8B76DD58 /* DepreciationCalculator.swift in Sources */,
-                               767B05BF2D4C5F9E00566C25 /* GoogleSheetsResponse.swift in Sources */,
+				767B05BF2D4C5F9E00566C25 /* GoogleSheetsResponse.swift in Sources */,
 				B6A6D6DC2DD8FD4E00378BFF /* ErrorBanner.swift in Sources */,
 				AA12BBCC44D055EE00112233 /* SuccessBanner.swift in Sources */,
 				B6A6D6DA2DD84F5000378BFF /* EditItemViewModel.swift in Sources */,

--- a/RoomRoster.xcodeproj/project.pbxproj
+++ b/RoomRoster.xcodeproj/project.pbxproj
@@ -66,9 +66,9 @@
 		B6D80EFA2E28259300748907 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = B6D80EF92E28259300748907 /* GoogleService-Info.plist */; };
 		B6D80EFB2E28CF5800748907 /* Spreadsheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9022FF3CD87CA507378085C4 /* Spreadsheet.swift */; };
 		B6D80EFD2E28DD8D00748907 /* SpreadsheetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D80EFC2E28DD8D00748907 /* SpreadsheetManager.swift */; };
-                B6D80EFE2E295A1600748907 /* HapticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77809C47FCD59CC9A4E795CC /* HapticManager.swift */; };
+		B6D80EFE2E295A1600748907 /* HapticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77809C47FCD59CC9A4E795CC /* HapticManager.swift */; };
 		0A2B89787187428E8B76DD58 /* DepreciationCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A63CDB2EA6A42EA93C1D13D /* DepreciationCalculator.swift */; };
-                B6E684CC2DCFB10400EE608B /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = B6E684CB2DCFB10400EE608B /* FirebaseCrashlytics */; };
+		B6E684CC2DCFB10400EE608B /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = B6E684CB2DCFB10400EE608B /* FirebaseCrashlytics */; };
 		B6E684D02DD03A6400EE608B /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = B6E684CF2DD03A6400EE608B /* Sentry */; };
 		B6E684D32DD03D2400EE608B /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = B6E684D22DD03D2400EE608B /* FirebaseStorage */; };
 		B6E684D52DD176DA00EE608B /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E684D42DD176D900EE608B /* Logger.swift */; };
@@ -81,7 +81,7 @@
 		B6F9649F2DB02BB60093089A /* FirebaseAppDistribution-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = B6F9649E2DB02BB60093089A /* FirebaseAppDistribution-Beta */; };
 		B6F964A12DB02C470093089A /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = B6F964A02DB02C470093089A /* FirebaseAuth */; };
 		B6F964A32DB02C470093089A /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = B6F964A22DB02C470093089A /* FirebaseStorage */; };
-                B7F2B3A12FF645E8A0FF1234 /* SheetsUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F2B3A12FF645E8A0FF1235 /* SheetsUtilsTests.swift */; };
+		B7F2B3A12FF645E8A0FF1234 /* SheetsUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F2B3A12FF645E8A0FF1235 /* SheetsUtilsTests.swift */; };
 		7B030D6795A8463589912FAE /* DepreciationCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2ACBFBB75EA4E3C9514A9AB /* DepreciationCalculatorTests.swift */; };
                 C616CDE1A2B34C5D67890ABE /* SalesDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C616CDE1A2B34C5D67890ABD /* SalesDetailsView.swift */; };
 		CE2487F2AA23494BBE56993D /* ReportsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12FE82B0693248D49E8D77BB /* ReportsViewModel.swift */; };
@@ -141,9 +141,9 @@
 		767E82D42D8F356500B48011 /* EditItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditItemView.swift; sourceTree = "<group>"; };
 		767E82D62D8F3ABE00B48011 /* AuthenticationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationManager.swift; sourceTree = "<group>"; };
 		767E82DF2D8F52FF00B48011 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-                77809C47FCD59CC9A4E795CC /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
+		77809C47FCD59CC9A4E795CC /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
 		8A63CDB2EA6A42EA93C1D13D /* DepreciationCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepreciationCalculator.swift; sourceTree = "<group>"; };
-                8BC8C5F5D40748AD93602E33 /* SalesServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesServiceTests.swift; sourceTree = "<group>"; };
+		8BC8C5F5D40748AD93602E33 /* SalesServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesServiceTests.swift; sourceTree = "<group>"; };
 		9022FF3CD87CA507378085C4 /* Spreadsheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spreadsheet.swift; sourceTree = "<group>"; };
 		9062D441F4874BA89C2A0A1E /* InventoryServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InventoryServiceTests.swift; sourceTree = "<group>"; };
 		A4280063F1BA4122A570E8B9 /* InventoryUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InventoryUITests.swift; sourceTree = "<group>"; };
@@ -180,7 +180,7 @@
 		D635C54A7B58948D1F8036B4 /* SpreadsheetManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpreadsheetManagerTests.swift; sourceTree = "<group>"; };
 		E32FE1D99B3B44E6A6801234 /* SalesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesViewModel.swift; sourceTree = "<group>"; };
 		E71B5019D5A040FCBB81807B /* ItemValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemValidatorTests.swift; sourceTree = "<group>"; };
-                F1DB1AD2C44D425AB9A59153 /* SellItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellItemViewModel.swift; sourceTree = "<group>"; };
+		F1DB1AD2C44D425AB9A59153 /* SellItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellItemViewModel.swift; sourceTree = "<group>"; };
 		F2ACBFBB75EA4E3C9514A9AB /* DepreciationCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepreciationCalculatorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -249,7 +249,7 @@
 				767E82CA2D8F1B2C00B48011 /* ItemDetailsViewModel.swift */,
 				767B05BC2D4C5E1700566C25 /* InventoryViewModel.swift */,
 				12FE82B0693248D49E8D77BB /* ReportsViewModel.swift */,
-				F1DB1AD2C44D425AB9A59153 /* SellItemViewModel.swift */,
+		F1DB1AD2C44D425AB9A59153 /* SellItemViewModel.swift */,
 				E32FE1D99B3B44E6A6801234 /* SalesViewModel.swift */,
 			);
 			path = ViewModels;
@@ -344,7 +344,7 @@
 				BF137618CD644A1997B55ED6 /* MockNetworkService.swift */,
 				614508236AFA4269887FF35A /* RoomServiceTests.swift */,
 				4AC01C73ED7A4FBC9EECB3D3 /* ViewModelTests.swift */,
-				8BC8C5F5D40748AD93602E33 /* SalesServiceTests.swift */,
+		8BC8C5F5D40748AD93602E33 /* SalesServiceTests.swift */,
 				D635C54A7B58948D1F8036B4 /* SpreadsheetManagerTests.swift */,
 				B7F2B3A12FF645E8A0FF1235 /* SheetsUtilsTests.swift */,
 				F2ACBFBB75EA4E3C9514A9AB /* DepreciationCalculatorTests.swift */,
@@ -371,7 +371,7 @@
 				767E82D62D8F3ABE00B48011 /* AuthenticationManager.swift */,
 				767E82D22D8F34C800B48011 /* Extensions.swift */,
 				B6E684D42DD176D900EE608B /* Logger.swift */,
-				77809C47FCD59CC9A4E795CC /* HapticManager.swift */,
+		77809C47FCD59CC9A4E795CC /* HapticManager.swift */,
 				8A63CDB2EA6A42EA93C1D13D /* DepreciationCalculator.swift */,
 				B61A9BD72DD6650000D04E9A /* SheetsUtils.swift */,
                         );
@@ -593,8 +593,8 @@
 				7DB3EA08C76F4E048B379677 /* ViewModelTests.swift in Sources */,
 				A787349732EA468CB09F1E52 /* SalesServiceTests.swift in Sources */,
 				630A8C62F5BBC9555EEC2E18 /* SpreadsheetManagerTests.swift in Sources */,
-				B7F2B3A12FF645E8A0FF1234 /* SheetsUtilsTests.swift in Sources */,
-				B7F2B3A12FF645E8A0FF1234 /* SheetsUtilsTests.swift in Sources */,
+		B7F2B3A12FF645E8A0FF1234 /* SheetsUtilsTests.swift in Sources */,
+		B7F2B3A12FF645E8A0FF1234 /* SheetsUtilsTests.swift in Sources */,
 				7B030D6795A8463589912FAE /* DepreciationCalculatorTests.swift in Sources */,
                         );
                         runOnlyForDeploymentPostprocessing = 0;

--- a/RoomRoster.xcodeproj/project.pbxproj
+++ b/RoomRoster.xcodeproj/project.pbxproj
@@ -249,7 +249,7 @@
 				767E82CA2D8F1B2C00B48011 /* ItemDetailsViewModel.swift */,
 				767B05BC2D4C5E1700566C25 /* InventoryViewModel.swift */,
 				12FE82B0693248D49E8D77BB /* ReportsViewModel.swift */,
-		F1DB1AD2C44D425AB9A59153 /* SellItemViewModel.swift */,
+				F1DB1AD2C44D425AB9A59153 /* SellItemViewModel.swift */,
 				E32FE1D99B3B44E6A6801234 /* SalesViewModel.swift */,
 			);
 			path = ViewModels;
@@ -344,7 +344,7 @@
 				BF137618CD644A1997B55ED6 /* MockNetworkService.swift */,
 				614508236AFA4269887FF35A /* RoomServiceTests.swift */,
 				4AC01C73ED7A4FBC9EECB3D3 /* ViewModelTests.swift */,
-		8BC8C5F5D40748AD93602E33 /* SalesServiceTests.swift */,
+				8BC8C5F5D40748AD93602E33 /* SalesServiceTests.swift */,
 				D635C54A7B58948D1F8036B4 /* SpreadsheetManagerTests.swift */,
 				B7F2B3A12FF645E8A0FF1235 /* SheetsUtilsTests.swift */,
 				F2ACBFBB75EA4E3C9514A9AB /* DepreciationCalculatorTests.swift */,
@@ -371,7 +371,7 @@
 				767E82D62D8F3ABE00B48011 /* AuthenticationManager.swift */,
 				767E82D22D8F34C800B48011 /* Extensions.swift */,
 				B6E684D42DD176D900EE608B /* Logger.swift */,
-		77809C47FCD59CC9A4E795CC /* HapticManager.swift */,
+				77809C47FCD59CC9A4E795CC /* HapticManager.swift */,
 				8A63CDB2EA6A42EA93C1D13D /* DepreciationCalculator.swift */,
 				B61A9BD72DD6650000D04E9A /* SheetsUtils.swift */,
                         );
@@ -593,8 +593,8 @@
 				7DB3EA08C76F4E048B379677 /* ViewModelTests.swift in Sources */,
 				A787349732EA468CB09F1E52 /* SalesServiceTests.swift in Sources */,
 				630A8C62F5BBC9555EEC2E18 /* SpreadsheetManagerTests.swift in Sources */,
-		B7F2B3A12FF645E8A0FF1234 /* SheetsUtilsTests.swift in Sources */,
-		B7F2B3A12FF645E8A0FF1234 /* SheetsUtilsTests.swift in Sources */,
+				B7F2B3A12FF645E8A0FF1234 /* SheetsUtilsTests.swift in Sources */,
+				B7F2B3A12FF645E8A0FF1234 /* SheetsUtilsTests.swift in Sources */,
 				7B030D6795A8463589912FAE /* DepreciationCalculatorTests.swift in Sources */,
                         );
                         runOnlyForDeploymentPostprocessing = 0;

--- a/RoomRoster/Models/Item.swift
+++ b/RoomRoster/Models/Item.swift
@@ -100,3 +100,9 @@ extension Item {
               lastKnownRoom: .empty(), updatedBy: "", lastUpdated: nil, propertyTag: nil)
     }
 }
+
+extension Item {
+    var depreciatedValue: Double? {
+        DepreciationCalculator.depreciatedValue(for: self, annualRate: 0.1)
+    }
+}

--- a/RoomRoster/Utilities/DepreciationCalculator.swift
+++ b/RoomRoster/Utilities/DepreciationCalculator.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct DepreciationCalculator {
+    static func depreciatedValue(for item: Item, annualRate: Double) -> Double? {
+        guard let price = item.estimatedPrice,
+              let added = Date.fromShortString(item.dateAdded) else { return nil }
+        let months = Calendar.current.dateComponents([.month], from: added, to: Date()).month ?? 0
+        let monthlyRate = annualRate / 12
+        return price * pow(1 - monthlyRate, Double(max(0, months)))
+    }
+}

--- a/RoomRoster/Utilities/Strings.swift
+++ b/RoomRoster/Utilities/Strings.swift
@@ -121,6 +121,7 @@ struct Strings {
         static let tag = "Property Tag:"
         static let dateAdded = "Date Added:"
         static let priceTitle = "Estimated Price:"
+        static let depreciatedPriceTitle = "Current Value:"
         static let status = "Status:"
         static let room = "Last Known Room:"
         static func dateUpdated(_ date: String) -> String {

--- a/RoomRoster/ViewModels/ReportsViewModel.swift
+++ b/RoomRoster/ViewModels/ReportsViewModel.swift
@@ -57,7 +57,7 @@ final class ReportsViewModel: ObservableObject {
     }
 
     private func computeTotalValue(for items: [Item]) {
-        totalValue = items.compactMap { $0.estimatedPrice }.reduce(0, +)
+        totalValue = items.compactMap { $0.depreciatedValue ?? $0.estimatedPrice }.reduce(0, +)
     }
 
     func loadRecentLogs(maxEntries: Int = 10) async {

--- a/RoomRoster/Views/ItemDetailsView.swift
+++ b/RoomRoster/Views/ItemDetailsView.swift
@@ -87,6 +87,13 @@ struct ItemDetailsView: View {
                             }
                         }
 
+                        if let current = item.depreciatedValue {
+                            HStack {
+                                Text(l10n.depreciatedPriceTitle).bold()
+                                Text("$\(current, specifier: "%.2f")")
+                            }
+                        }
+
                         HStack {
                             Text(l10n.status).bold()
                             Text(item.status.label)

--- a/RoomRoster/Views/ReportsView.swift
+++ b/RoomRoster/Views/ReportsView.swift
@@ -116,8 +116,6 @@ struct ReportsView: View {
                     }
                 }
 
-                }
-
             }
             .navigationTitle(l10n.title)
             .toolbar {
@@ -157,11 +155,8 @@ struct ReportsView: View {
             Spacer()
             Button(l10n.exportSearch) { shareURL = viewModel.exportCSV() }
         }
-
     }
 }
-
-
 extension URL: Identifiable {
     public var id: String { absoluteString }
 }

--- a/RoomRoster/Views/ReportsView.swift
+++ b/RoomRoster/Views/ReportsView.swift
@@ -117,8 +117,9 @@ struct ReportsView: View {
                 }
 
             }
-            .navigationTitle(l10n.title)
-            .toolbar {
+        }
+        .navigationTitle(l10n.title)
+        .toolbar {
                 if sheets.currentSheet != nil {
                     ToolbarItem(placement: .navigationBarTrailing) {
                         Menu {

--- a/RoomRoster/Views/ReportsView.swift
+++ b/RoomRoster/Views/ReportsView.swift
@@ -116,6 +116,8 @@ struct ReportsView: View {
                     }
                 }
 
+                }
+
             }
             .navigationTitle(l10n.title)
             .toolbar {
@@ -155,8 +157,10 @@ struct ReportsView: View {
             Spacer()
             Button(l10n.exportSearch) { shareURL = viewModel.exportCSV() }
         }
+
     }
 }
+
 
 extension URL: Identifiable {
     public var id: String { absoluteString }

--- a/RoomRoster/Views/ReportsView.swift
+++ b/RoomRoster/Views/ReportsView.swift
@@ -161,4 +161,3 @@ extension URL: Identifiable {
     public var id: String { absoluteString }
 }
 
-}

--- a/RoomRoster/Views/ReportsView.swift
+++ b/RoomRoster/Views/ReportsView.swift
@@ -160,3 +160,5 @@ struct ReportsView: View {
 extension URL: Identifiable {
     public var id: String { absoluteString }
 }
+
+}

--- a/RoomRosterTests/DepreciationCalculatorTests.swift
+++ b/RoomRosterTests/DepreciationCalculatorTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import RoomRoster
+
+final class DepreciationCalculatorTests: XCTestCase {
+    func testDepreciatedValueSixMonths() {
+        let now = Date()
+        let past = Calendar.current.date(byAdding: .month, value: -6, to: now)!
+        let item = Item(id: "1", imageURL: "", name: "Test", description: "", quantity: 1,
+                        dateAdded: past.toShortString(), estimatedPrice: 120,
+                        status: .available, lastKnownRoom: .empty(), updatedBy: "", lastUpdated: nil, propertyTag: nil)
+        let expected = 120 * pow(1 - 0.12/12, 6)
+        let value = DepreciationCalculator.depreciatedValue(for: item, annualRate: 0.12)
+        XCTAssertEqual(value!, expected, accuracy: 0.0001)
+    }
+
+    func testDepreciatedValueNoMonths() {
+        let now = Date()
+        let item = Item(id: "1", imageURL: "", name: "Test", description: "", quantity: 1,
+                        dateAdded: now.toShortString(), estimatedPrice: 100,
+                        status: .available, lastKnownRoom: .empty(), updatedBy: "", lastUpdated: nil, propertyTag: nil)
+        let value = DepreciationCalculator.depreciatedValue(for: item, annualRate: 0.1)
+        XCTAssertEqual(value!, 100, accuracy: 0.0001)
+    }
+
+    func testDepreciatedValueInvalidDate() {
+        let item = Item(id: "1", imageURL: "", name: "Test", description: "", quantity: 1,
+                        dateAdded: "invalid", estimatedPrice: 50,
+                        status: .available, lastKnownRoom: .empty(), updatedBy: "", lastUpdated: nil, propertyTag: nil)
+        XCTAssertNil(DepreciationCalculator.depreciatedValue(for: item, annualRate: 0.1))
+    }
+}


### PR DESCRIPTION
## Summary
- compute depreciated item values in new `DepreciationCalculator`
- expose `depreciatedValue` via `Item` extension
- show current value in `ItemDetailsView`
- update inventory total value in `ReportsViewModel`
- localise label for depreciated price
- add unit tests for depreciation logic
- integrate new files in Xcode project
- fix project file indentation and remove header comments

## Testing
- `swift --version`
- `swiftc RoomRoster/Utilities/DepreciationCalculator.swift -emit-module -o /tmp/dc.o` *(fails: cannot find type 'Item')*
- `swiftc RoomRosterTests/DepreciationCalculatorTests.swift -emit-module -o /tmp/dctest.o -I RoomRoster` *(fails: no such module 'RoomRoster')*


------
https://chatgpt.com/codex/tasks/task_e_687dadd60880832cb01b96f9b33bc2ae