### PR TITLE
Fix inventory refresh after edit

### DIFF
--- a/RoomRoster/Views/ItemDetailsView.swift
+++ b/RoomRoster/Views/ItemDetailsView.swift
@@ -241,6 +241,7 @@ struct ItemDetailsView: View {
                         await HistoryLogService()
                             .logChanges(old: oldItem, new: updatedItem, updatedBy: updatedBy)
                         await viewModel.fetchItemHistory(for: item.id)
+                        await inventoryVM.fetchInventory()
                     } catch {
                         Logger.log(error, extra: [
                             "description": "Error updating item",


### PR DESCRIPTION
## Summary
- refresh inventory list after editing item details

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6883eeab7d54832cb3c40ae029dd34a9