### PR TITLE
Add success banners after item and sale actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Common components like banners and buttons automatically adapt their style on ea
 - **Item Details:** Tap on any item in the list to view its detailed information, including a history log and color-coded status.
 - **Edit Items:** Use the "Edit Item" button in the details view to modify item information. Changes are applied locally and can be extended to update remotely.
 - **Sell Items:** From an item's details you can record a sale which updates the Google Sheet and emails a receipt.
+- **Banners:** Success and error banners appear over the current view so feedback is always visible on both iOS and macOS.
 
 ## Configuration
 

--- a/RoomRoster/Utilities/Strings.swift
+++ b/RoomRoster/Utilities/Strings.swift
@@ -69,6 +69,7 @@ struct Strings {
         static let uploadingImage = "Uploading Image…"
         static let imageURL = "Image URL"
         static let photo = "Photo"
+        static let success = "Item created successfully"
         struct basicInfo {
             static let title = "Basic Information"
             static let name = "Name"
@@ -147,6 +148,7 @@ struct Strings {
     // MARK: - EditItemView
     struct editItem {
         static let title = "Edit Item"
+        static let success = "Item updated successfully"
         struct photo {
             static let title = "Photo"
             static let emptyState = "No Photo"
@@ -285,5 +287,6 @@ struct Strings {
         static let receiptSection = "Receipt"
         static let editButton = "Edit"
         static let editTitle = "Edit Sale"
+        static let editSuccess = "Sale updated successfully"
     }
 }

--- a/RoomRoster/Views/CreateItemView.swift
+++ b/RoomRoster/Views/CreateItemView.swift
@@ -33,12 +33,8 @@ struct CreateItemView: View {
     }
 
     private var content: some View {
-        VStack {
-            VStack {
-                if let error = viewModel.errorMessage {
-                    ErrorBanner(message: error)
-                }
-                Form {
+        ZStack(alignment: .bottom) {
+            Form {
                     Section {
                         CombinedImagePickerButton(image: $viewModel.pickedImage)
                             .onChange(of: viewModel.pickedImage) { _, img in
@@ -211,6 +207,11 @@ struct CreateItemView: View {
                 .disabled(viewModel.newItem.name.isEmpty || viewModel.newItem.description.isEmpty || viewModel.tagError != nil || viewModel.newItem.lastKnownRoom == Room.placeholder())
                 .platformButtonStyle()
                 }
+            }
+            if let error = viewModel.errorMessage {
+                ErrorBanner(message: error)
+                    .allowsHitTesting(false)
+                    .padding()
             }
             .alert(
                 l10n.addRoom.title,

--- a/RoomRoster/Views/InventoryView.swift
+++ b/RoomRoster/Views/InventoryView.swift
@@ -52,7 +52,8 @@ struct InventoryView: View {
     }
 
     var body: some View {
-        Group {
+        ZStack(alignment: .bottomTrailing) {
+            Group {
 #if os(macOS)
             NavigationSplitView {
                 listPane
@@ -147,6 +148,11 @@ struct InventoryView: View {
             syncSelectionWithInventory()
         }
 #endif
+        if let message = successMessage {
+            SuccessBanner(message: message)
+                .allowsHitTesting(false)
+                .padding()
+        }
     }
 
 #if os(macOS)
@@ -272,9 +278,6 @@ struct InventoryView: View {
             VStack {
                 if let error = viewModel.errorMessage {
                     ErrorBanner(message: error)
-                }
-                if let message = successMessage {
-                    SuccessBanner(message: message)
                 }
                 Spacer()
             }

--- a/RoomRoster/Views/InventoryView.swift
+++ b/RoomRoster/Views/InventoryView.swift
@@ -53,7 +53,7 @@ struct InventoryView: View {
 
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
-            Group {
+        Group {
 #if os(macOS)
             NavigationSplitView {
                 listPane
@@ -66,6 +66,7 @@ struct InventoryView: View {
             }
 #endif
         }
+    }
 #if !os(macOS)
         .platformPopup(isPresented: $showCreateItemView) {
             CreateItemView(

--- a/RoomRoster/Views/InventoryView.swift
+++ b/RoomRoster/Views/InventoryView.swift
@@ -154,6 +154,11 @@ struct InventoryView: View {
                 .allowsHitTesting(false)
                 .padding()
         }
+        if let error = viewModel.errorMessage {
+            ErrorBanner(message: error)
+                .allowsHitTesting(false)
+                .padding()
+        }
     }
 
 #if os(macOS)
@@ -276,13 +281,6 @@ struct InventoryView: View {
     @ViewBuilder
     private var listPane: some View {
         ZStack(alignment: .bottomTrailing) {
-            VStack {
-                if let error = viewModel.errorMessage {
-                    ErrorBanner(message: error)
-                }
-                Spacer()
-            }
-            .allowsHitTesting(false)
 
 #if os(macOS)
             List(selection: selectionBinding) {

--- a/RoomRoster/Views/ItemDetailsView.swift
+++ b/RoomRoster/Views/ItemDetailsView.swift
@@ -25,6 +25,7 @@ struct ItemDetailsView: View {
     @State private var sale: Sale?
     @State private var saleSuccess: String?
     @State private var saleError: String?
+    @State private var editSuccess: String?
     @StateObject private var viewModel = ItemDetailsViewModel()
     @State private var shareURL: URL?
 
@@ -49,6 +50,9 @@ struct ItemDetailsView: View {
                         ErrorBanner(message: error)
                     }
                     if let message = saleSuccess {
+                        SuccessBanner(message: message)
+                    }
+                    if let message = editSuccess {
                         SuccessBanner(message: message)
                     }
                     if let sellError = saleError {
@@ -285,6 +289,11 @@ struct ItemDetailsView: View {
                             .logChanges(old: oldItem, new: updatedItem, updatedBy: updatedBy)
                         await viewModel.fetchItemHistory(for: item.id)
                         await inventoryVM.fetchInventory()
+                        editSuccess = Strings.editItem.success
+                        HapticManager.shared.success()
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
+                            withAnimation { editSuccess = nil }
+                        }
                     } catch {
                         Logger.log(error, extra: [
                             "description": "Error updating item",

--- a/RoomRoster/Views/ItemDetailsView.swift
+++ b/RoomRoster/Views/ItemDetailsView.swift
@@ -43,21 +43,9 @@ struct ItemDetailsView: View {
 #endif
 
     var body: some View {
-        ZStack {
+        ZStack(alignment: .bottom) {
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
-                    if let error = viewModel.errorMessage {
-                        ErrorBanner(message: error)
-                    }
-                    if let message = saleSuccess {
-                        SuccessBanner(message: message)
-                    }
-                    if let message = editSuccess {
-                        SuccessBanner(message: message)
-                    }
-                    if let sellError = saleError {
-                        ErrorBanner(message: sellError)
-                    }
                     if let url = URL(string: item.imageURL) {
                         AsyncImage(url: url) { image in
                             image.resizable().scaledToFit()
@@ -183,6 +171,22 @@ struct ItemDetailsView: View {
                 }
             }
             #endif
+            VStack(spacing: 4) {
+                if let message = saleSuccess {
+                    SuccessBanner(message: message)
+                }
+                if let message = editSuccess {
+                    SuccessBanner(message: message)
+                }
+                if let sellError = saleError {
+                    ErrorBanner(message: sellError)
+                }
+                if let error = viewModel.errorMessage {
+                    ErrorBanner(message: error)
+                }
+            }
+            .allowsHitTesting(false)
+            .padding()
         }
         .navigationTitle(l10n.title)
         .toolbar {

--- a/RoomRoster/Views/SalesDetailsView.swift
+++ b/RoomRoster/Views/SalesDetailsView.swift
@@ -20,6 +20,7 @@ struct SalesDetailsView: View {
     )
     @State private var shareURL: URL?
     @State private var errorMessage: String?
+    @State private var editSuccess: String?
     private let downloader = FileDownloadService()
 
     var body: some View {
@@ -79,6 +80,10 @@ struct SalesDetailsView: View {
                 VStack { Spacer(); ErrorBanner(message: errorMessage) }
                     .allowsHitTesting(false)
             }
+            if let message = editSuccess {
+                VStack { Spacer(); SuccessBanner(message: message) }
+                    .allowsHitTesting(false)
+            }
         }
         .toolbar {
             Button(l10n.editButton) {
@@ -89,6 +94,11 @@ struct SalesDetailsView: View {
         .platformPopup(isPresented: $showingEdit) {
             EditSaleView(viewModel: EditSaleViewModel(sale: editableSale)) { updated in
                 editableSale = updated
+                editSuccess = Strings.saleDetails.editSuccess
+                HapticManager.shared.success()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
+                    withAnimation { editSuccess = nil }
+                }
             }
         }
         .sheet(item: $shareURL) { url in

--- a/RoomRoster/Views/SalesView.swift
+++ b/RoomRoster/Views/SalesView.swift
@@ -20,6 +20,7 @@ struct SalesView: View {
 #endif
 
     var body: some View {
+        ZStack(alignment: .bottom) {
         Group {
 #if os(macOS)
             NavigationSplitView {
@@ -41,6 +42,12 @@ struct SalesView: View {
                 listPane
             }
 #endif
+        }
+        if let error = viewModel.errorMessage {
+            ErrorBanner(message: error)
+                .allowsHitTesting(false)
+                .padding()
+        }
         }
         .navigationTitle(l10n.title)
         .task {
@@ -101,10 +108,6 @@ struct SalesView: View {
 
     @ViewBuilder
     private var listContent: some View {
-        if let error = viewModel.errorMessage {
-            ErrorBanner(message: error)
-        }
-
         if sheets.currentSheet == nil {
             Text(Strings.inventory.selectSheetPrompt)
                 .foregroundColor(.secondary)


### PR DESCRIPTION
## Summary
- show success banners in InventoryView and ItemDetailsView
- show success banner when editing a sale in SalesDetailsView
- add success strings for create, edit, and sale updates

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project RoomRoster.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888d8bdac14832c960aea2af81b246e