### PR TITLE
Fix receipt download for image-based receipts

### DIFF
--- a/RoomRoster/ViewModels/ItemDetailsViewModel.swift
+++ b/RoomRoster/ViewModels/ItemDetailsViewModel.swift
@@ -37,10 +37,25 @@ class ItemDetailsViewModel: ObservableObject {
         try await downloader.download(from: url)
     }
 
-    func downloadReceipt(for itemId: String) async throws -> URL {
-        let data = try await receiptService.loadReceipt(for: itemId)
+    func downloadReceipt(for item: Item) async throws -> URL {
+        let fileType: ReceiptFileType
+        if let urlString = item.purchaseReceiptURL,
+           let url = URL(string: urlString) {
+            switch url.pathExtension.lowercased() {
+            case "jpg", "jpeg": fileType = .jpg
+            case "png": fileType = .png
+            default: fileType = .pdf
+            }
+        } else {
+            fileType = .pdf
+        }
+
+        let data = try await receiptService.loadReceipt(
+            for: item.id,
+            type: fileType
+        )
         let fileURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("\(itemId).pdf")
+            .appendingPathComponent("\(item.id).\(fileType.fileExtension)")
         try data.write(to: fileURL)
         return fileURL
     }

--- a/RoomRoster/Views/ItemDetailsView.swift
+++ b/RoomRoster/Views/ItemDetailsView.swift
@@ -221,7 +221,7 @@ struct ItemDetailsView: View {
                             Button(l10n.downloadReceipt) {
                                 Task {
                                     do {
-                                        let downloaded = try await viewModel.downloadReceipt(for: item.id)
+                                        let downloaded = try await viewModel.downloadReceipt(for: item)
 #if os(macOS)
                                         NSWorkspace.shared.open(downloaded)
 #else


### PR DESCRIPTION
## Summary
- correctly infer receipt file type from `Item.purchaseReceiptURL`
- open the downloaded receipt with the correct extension

## Testing
- `swift test --enable-test-discovery` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6888d9ed06c0832ca7ad2b4d99e1ab48