### PR TITLE
Fix Sale Details sheet and add missing image placeholder

### DIFF
--- a/RoomRoster/Utilities/Strings.swift
+++ b/RoomRoster/Utilities/Strings.swift
@@ -128,6 +128,7 @@ struct Strings {
         static func dateUpdated(_ date: String) -> String {
             "Last Updated: \(date)"
         }
+        static let noImage = "No Image"
         struct logs {
             static let title = "History Log"
             static let loading = "Loading history…"

--- a/RoomRoster/Views/ItemDetailsView.swift
+++ b/RoomRoster/Views/ItemDetailsView.swift
@@ -54,7 +54,7 @@ struct ItemDetailsView: View {
                     if let sellError = saleError {
                         ErrorBanner(message: sellError)
                     }
-                    if let url = URL(string: item.imageURL) {
+                    if let url = URL(string: item.imageURL), !item.imageURL.isEmpty {
                         AsyncImage(url: url) { image in
                             image.resizable().scaledToFit()
                         } placeholder: {
@@ -62,6 +62,12 @@ struct ItemDetailsView: View {
                         }
                         .frame(height: 250)
                         .cornerRadius(12)
+                    } else {
+                        Text(Strings.itemDetails.noImage)
+                            .frame(maxWidth: .infinity, minHeight: 250)
+                            .foregroundColor(.secondary)
+                            .background(Color.secondary.opacity(0.1))
+                            .cornerRadius(12)
                     }
 
                     if item.purchaseReceiptURL != nil {
@@ -325,17 +331,17 @@ struct ItemDetailsView: View {
                 }
             }
         }
-        .platformPopup(isPresented: $showingSaleDetails) {
-            if let sale {
-                SalesDetailsView(sale: sale, itemName: item.name)
-            }
-        }
         #if canImport(UIKit)
         .sheet(item: $shareURL) { url in
             ShareSheet(activityItems: [url])
         }
         #endif
         #endif // os(iOS)
+        .platformPopup(isPresented: $showingSaleDetails) {
+            if let sale {
+                SalesDetailsView(sale: sale, itemName: item.name)
+            }
+        }
         .onAppear {
             Logger.page("ItemDetailsView")
             Task { await AuthenticationManager.shared.signIn() }


### PR DESCRIPTION
## Summary
- support showing Sale Details sheet on macOS
- display a placeholder when an item has no image

## Testing
- `swift --version`
- `xcodebuild -list -project RoomRoster.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888d9e01c18832c81b77c28e24383c4