### PR TITLE
Enhance sale details UX

### DIFF
--- a/RoomRoster/Utilities/Strings.swift
+++ b/RoomRoster/Utilities/Strings.swift
@@ -289,5 +289,7 @@ struct Strings {
         static let editButton = "Edit"
         static let editTitle = "Edit Sale"
         static let editSuccess = "Sale updated successfully"
+        static let noReceipt = "No Receipt"
+        static let failedToUpdate = "Failed to update sale. Please try again."
     }
 }

--- a/RoomRoster/Views/Components/ReceiptImageView.swift
+++ b/RoomRoster/Views/Components/ReceiptImageView.swift
@@ -24,8 +24,9 @@ struct ReceiptImageView: View {
             Label("View Receipt", systemImage: "doc")
                 .foregroundColor(.blue)
         } else {
-            Text("No receipt")
-                .foregroundColor(.gray)
+            Text(Strings.saleDetails.noReceipt)
+                .foregroundColor(.secondary)
+                .font(.caption)
         }
     }
 }

--- a/RoomRoster/Views/EditSaleView.swift
+++ b/RoomRoster/Views/EditSaleView.swift
@@ -5,17 +5,27 @@ struct EditSaleView: View {
     @StateObject var viewModel: EditSaleViewModel
     var onSave: (Sale) -> Void
 
+    @State private var saveError: String?
+
     var body: some View {
-#if os(macOS)
         content
-#else
-        NavigationStack { content }
-#endif
+            .navigationTitle(Strings.saleDetails.editTitle)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Strings.general.cancel) { dismiss() }
+                }
+            }
+            .overlay {
+                if let saveError {
+                    VStack { Spacer(); ErrorBanner(message: saveError) }
+                        .allowsHitTesting(false)
+                }
+            }
     }
 
     private var content: some View {
         Form {
-                Section("Sale Receipt") {
+            Section("Sale Receipt") {
                     ReceiptImageView(urlString: viewModel.sale.receiptImageURL)
                     CombinedImagePickerButton(image: $viewModel.pickedReceiptImage)
                         .onChange(of: viewModel.pickedReceiptImage) { _, img in
@@ -37,26 +47,25 @@ struct EditSaleView: View {
                             .font(.caption)
                     }
                 }
-            }
-            .navigationTitle(Strings.saleDetails.editTitle)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
-                }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Save") {
-                        Task {
-                            do {
-                                try await viewModel.saveUpdates()
-                                onSave(viewModel.sale)
-                                dismiss()
-                            } catch {
-                                HapticManager.shared.error()
+
+            Section {
+                Button(Strings.general.save) {
+                    Task {
+                        do {
+                            try await viewModel.saveUpdates()
+                            onSave(viewModel.sale)
+                            dismiss()
+                        } catch {
+                            saveError = Strings.saleDetails.failedToUpdate
+                            HapticManager.shared.error()
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
+                                withAnimation { saveError = nil }
                             }
                         }
                     }
-                    .platformButtonStyle()
                 }
+                .platformButtonStyle()
             }
         }
+    }
     }

--- a/RoomRoster/Views/SalesDetailsView.swift
+++ b/RoomRoster/Views/SalesDetailsView.swift
@@ -5,19 +5,6 @@ private typealias l10n = Strings.saleDetails
 struct SalesDetailsView: View {
     let sale: Sale
     let itemName: String
-    @State private var showingEdit = false
-    @State private var editableSale = Sale(
-        itemId: "",
-        date: Date(),
-        price: nil,
-        condition: .new,
-        buyerName: "",
-        buyerContact: nil,
-        soldBy: "",
-        department: "",
-        receiptImageURL: nil,
-        receiptPDFURL: nil
-    )
     @State private var shareURL: URL?
     @State private var errorMessage: String?
     @State private var editSuccess: String?
@@ -36,12 +23,11 @@ struct SalesDetailsView: View {
                 row(l10n.soldBy, sale.soldBy)
                 row(l10n.department, sale.department)
             }
-            if (sale.receiptImageURL?.isEmpty == false) || (sale.receiptPDFURL?.isEmpty == false) {
-                Section(l10n.receiptSection) {
-                    ReceiptImageView(urlString: sale.receiptImageURL)
-                    if let imgURLString = sale.receiptImageURL,
-                       !imgURLString.isEmpty,
-                       let url = URL(string: imgURLString) {
+            Section(l10n.receiptSection) {
+                ReceiptImageView(urlString: sale.receiptImageURL)
+                if let imgURLString = sale.receiptImageURL,
+                   !imgURLString.isEmpty,
+                   let url = URL(string: imgURLString) {
                         Button(Strings.itemDetails.downloadImage) {
                             Task {
                                 do {
@@ -54,10 +40,10 @@ struct SalesDetailsView: View {
                             }
                         }
                         .platformButtonStyle()
-                    }
-                    if let pdf = sale.receiptPDFURL,
-                       !pdf.isEmpty,
-                       let url = URL(string: pdf) {
+                }
+                if let pdf = sale.receiptPDFURL,
+                   !pdf.isEmpty,
+                   let url = URL(string: pdf) {
                         Button(Strings.itemDetails.downloadReceipt) {
                             Task {
                                 do {
@@ -71,7 +57,6 @@ struct SalesDetailsView: View {
                         }
                         .platformButtonStyle()
                     }
-                }
             }
         }
         .navigationTitle(itemName)
@@ -86,19 +71,14 @@ struct SalesDetailsView: View {
             }
         }
         .toolbar {
-            Button(l10n.editButton) {
-                editableSale = sale
-                showingEdit = true
-            }
-        }
-        .platformPopup(isPresented: $showingEdit) {
-            EditSaleView(viewModel: EditSaleViewModel(sale: editableSale)) { updated in
-                editableSale = updated
+            NavigationLink(destination: EditSaleView(viewModel: EditSaleViewModel(sale: sale)) { _ in
                 editSuccess = Strings.saleDetails.editSuccess
                 HapticManager.shared.success()
                 DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
                     withAnimation { editSuccess = nil }
                 }
+            }) {
+                Text(l10n.editButton)
             }
         }
         .sheet(item: $shareURL) { url in


### PR DESCRIPTION
## Summary
- add new sale details strings
- tone down receipt placeholder
- show receipt section even when no receipt
- rework edit sale flow
- move save button and surface errors

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688a9bf0e27c832cb7f1db1886c64c59