### PR TITLE
Fix image picker preview logic

### DIFF
--- a/RoomRoster/Utilities/Strings.swift
+++ b/RoomRoster/Utilities/Strings.swift
@@ -155,6 +155,8 @@ struct Strings {
             static let emptyState = "No Photo"
             static let enter = "Select or Take Photo"
             static let loading = "Uploading Image…"
+            static let current = "Current Photo"
+            static let new = "New Photo"
         }
         struct basicInfo {
             static let title = "Basic Information"
@@ -286,6 +288,8 @@ struct Strings {
         static let soldBy = "Sold By:"
         static let department = "Department:"
         static let receiptSection = "Receipt"
+        static let currentReceipt = "Current Receipt"
+        static let newReceipt = "New Receipt"
         static let editButton = "Edit"
         static let editTitle = "Edit Sale"
         static let editSuccess = "Sale updated successfully"

--- a/RoomRoster/ViewModels/EditItemViewModel.swift
+++ b/RoomRoster/ViewModels/EditItemViewModel.swift
@@ -54,14 +54,10 @@ final class EditItemViewModel: ObservableObject {
 
     func onReceiptPicked(_ image: PlatformImage?) {
         pickedReceiptImage = image
-        guard let image else { return }
-        Task { await saveReceiptImage(image) }
     }
 
     func onReceiptPDFPicked(_ url: URL?) {
         pickedReceiptPDF = url
-        guard let url else { return }
-        Task { await saveReceiptPDF(from: url) }
     }
 
     private func saveReceiptImage(_ image: PlatformImage) async {

--- a/RoomRoster/ViewModels/EditSaleViewModel.swift
+++ b/RoomRoster/ViewModels/EditSaleViewModel.swift
@@ -3,6 +3,8 @@ import SwiftUI
 @MainActor
 final class EditSaleViewModel: ObservableObject {
     @Published var sale: Sale
+    let originalReceiptImageURL: String?
+    let originalReceiptPDFURL: String?
     @Published var pickedReceiptImage: PlatformImage?
     @Published var pickedReceiptPDF: URL?
     @Published var isUploading: Bool = false
@@ -17,6 +19,8 @@ final class EditSaleViewModel: ObservableObject {
         receiptService: SaleReceiptService = .init()
     ) {
         self.sale = sale
+        self.originalReceiptImageURL = sale.receiptImageURL
+        self.originalReceiptPDFURL = sale.receiptPDFURL
         self.saleService = saleService
         self.receiptService = receiptService
     }

--- a/RoomRoster/ViewModels/EditSaleViewModel.swift
+++ b/RoomRoster/ViewModels/EditSaleViewModel.swift
@@ -23,14 +23,10 @@ final class EditSaleViewModel: ObservableObject {
 
     func onReceiptPicked(_ image: PlatformImage?) {
         pickedReceiptImage = image
-        guard let image else { return }
-        Task { await uploadImage(image) }
     }
 
     func onReceiptPDFPicked(_ url: URL?) {
         pickedReceiptPDF = url
-        guard let url else { return }
-        Task { await uploadPDF(url) }
     }
 
     private func uploadImage(_ image: PlatformImage) async {
@@ -61,6 +57,12 @@ final class EditSaleViewModel: ObservableObject {
     }
 
     func saveUpdates() async throws {
+        if let image = pickedReceiptImage {
+            await uploadImage(image)
+        }
+        if let url = pickedReceiptPDF {
+            await uploadPDF(url)
+        }
         try await saleService.updateSale(sale)
     }
 }

--- a/RoomRoster/ViewModels/EditSaleViewModel.swift
+++ b/RoomRoster/ViewModels/EditSaleViewModel.swift
@@ -25,6 +25,16 @@ final class EditSaleViewModel: ObservableObject {
         self.receiptService = receiptService
     }
 
+    func refreshSale() async {
+        do {
+            if let fetched = try await saleService.fetchSale(for: sale.itemId) {
+                sale = fetched
+            }
+        } catch {
+            Logger.log(error, extra: ["description": "Failed to refresh sale in edit view"])
+        }
+    }
+
     func onReceiptPicked(_ image: PlatformImage?) {
         pickedReceiptImage = image
     }

--- a/RoomRoster/Views/EditItemView.swift
+++ b/RoomRoster/Views/EditItemView.swift
@@ -52,27 +52,31 @@ struct EditItemView: View {
         Form {
                 // MARK: – Photo Section
                 Section(header: Text(l10n.photo.title)) {
-                    if let url = URL(string: editableItem.imageURL),
-                            !editableItem.imageURL.isEmpty {
-                        AsyncImage(url: url) { img in
-                            img.resizable()
-                               .scaledToFit()
-                               .frame(height: 120)
-                               .cornerRadius(8)
-                        } placeholder: {
-                            ProgressView().frame(height: 120)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(l10n.photo.current)
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                        if let url = URL(string: editableItem.imageURL),
+                           !editableItem.imageURL.isEmpty {
+                            AsyncImage(url: url) { img in
+                                img.resizable()
+                                   .scaledToFit()
+                                   .frame(height: 120)
+                                   .cornerRadius(8)
+                            } placeholder: {
+                                ProgressView().frame(height: 120)
+                            }
+                        } else {
+                            Rectangle()
+                                .fill(Color.secondary.opacity(0.1))
+                                .frame(height: 120)
+                                .cornerRadius(8)
+                                .overlay(Text(l10n.photo.emptyState).foregroundColor(.gray))
                         }
-                    } else {
-                        Rectangle()
-                            .fill(Color.secondary.opacity(0.1))
-                            .frame(height: 120)
-                            .cornerRadius(8)
-                            .overlay(Text(l10n.photo.emptyState).foregroundColor(.gray))
                     }
 
-                    // Picker button
                     VStack(alignment: .leading, spacing: 4) {
-                        Text(l10n.photo.enter)
+                        Text(l10n.photo.new)
                             .font(.caption)
                             .foregroundColor(.gray)
                         CombinedImagePickerButton(image: $pickedImage)
@@ -94,15 +98,19 @@ struct EditItemView: View {
 
                 // MARK: – Purchase Receipt
                 Section(header: Text("Purchase Receipt")) {
-                    ReceiptImageView(urlString: editableItem.purchaseReceiptURL)
-                    CombinedImagePickerButton(image: $pickedReceiptImage)
-                        .onChange(of: pickedReceiptImage) { _, img in
-                            Task { await saveReceiptImage(img) }
-                        }
-                    PDFPickerButton(url: $pickedReceiptPDF)
-                        .onChange(of: pickedReceiptPDF) { _, url in
-                            Task { await saveReceiptPDF(url) }
-                        }
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(Strings.saleDetails.currentReceipt)
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                        ReceiptImageView(urlString: editableItem.purchaseReceiptURL)
+                    }
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(Strings.saleDetails.newReceipt)
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                        CombinedImagePickerButton(image: $pickedReceiptImage)
+                        PDFPickerButton(url: $pickedReceiptPDF)
+                    }
 
                     if isUploadingReceipt {
                         HStack {
@@ -245,6 +253,8 @@ struct EditItemView: View {
                         Task {
                             Logger.action("Pressed Save Button")
                             await uploadPickedImage()
+                            await saveReceiptImage(pickedReceiptImage)
+                            await saveReceiptPDF(pickedReceiptPDF)
                             if let newURL = temporaryImageURL {
                                 editableItem.imageURL = newURL
                             }

--- a/RoomRoster/Views/EditSaleView.swift
+++ b/RoomRoster/Views/EditSaleView.swift
@@ -20,7 +20,7 @@ struct EditSaleView: View {
                         Text(Strings.saleDetails.currentReceipt)
                             .font(.caption)
                             .foregroundColor(.gray)
-                        ReceiptImageView(urlString: viewModel.sale.receiptImageURL)
+                        ReceiptImageView(urlString: viewModel.originalReceiptImageURL)
                     }
                     VStack(alignment: .leading, spacing: 4) {
                         Text(Strings.saleDetails.newReceipt)

--- a/RoomRoster/Views/EditSaleView.swift
+++ b/RoomRoster/Views/EditSaleView.swift
@@ -16,15 +16,19 @@ struct EditSaleView: View {
     private var content: some View {
         Form {
                 Section("Sale Receipt") {
-                    ReceiptImageView(urlString: viewModel.sale.receiptImageURL)
-                    CombinedImagePickerButton(image: $viewModel.pickedReceiptImage)
-                        .onChange(of: viewModel.pickedReceiptImage) { _, img in
-                            viewModel.onReceiptPicked(img)
-                        }
-                    PDFPickerButton(url: $viewModel.pickedReceiptPDF)
-                        .onChange(of: viewModel.pickedReceiptPDF) { _, url in
-                            viewModel.onReceiptPDFPicked(url)
-                        }
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(Strings.saleDetails.currentReceipt)
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                        ReceiptImageView(urlString: viewModel.sale.receiptImageURL)
+                    }
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(Strings.saleDetails.newReceipt)
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                        CombinedImagePickerButton(image: $viewModel.pickedReceiptImage)
+                        PDFPickerButton(url: $viewModel.pickedReceiptPDF)
+                    }
                     if viewModel.isUploading {
                         HStack {
                             ProgressView()

--- a/RoomRoster/Views/EditSaleView.swift
+++ b/RoomRoster/Views/EditSaleView.swift
@@ -20,7 +20,8 @@ struct EditSaleView: View {
                         Text(Strings.saleDetails.currentReceipt)
                             .font(.caption)
                             .foregroundColor(.gray)
-                        ReceiptImageView(urlString: viewModel.originalReceiptImageURL)
+                        ReceiptImageView(urlString: viewModel.originalReceiptImageURL ??
+                            viewModel.originalReceiptPDFURL)
                     }
                     VStack(alignment: .leading, spacing: 4) {
                         Text(Strings.saleDetails.newReceipt)

--- a/RoomRoster/Views/EditSaleView.swift
+++ b/RoomRoster/Views/EditSaleView.swift
@@ -20,8 +20,12 @@ struct EditSaleView: View {
                         Text(Strings.saleDetails.currentReceipt)
                             .font(.caption)
                             .foregroundColor(.gray)
-                        ReceiptImageView(urlString: viewModel.originalReceiptImageURL ??
-                            viewModel.originalReceiptPDFURL)
+                        ReceiptImageView(
+                            urlString: viewModel.sale.receiptImageURL ??
+                                viewModel.sale.receiptPDFURL ??
+                                viewModel.originalReceiptImageURL ??
+                                viewModel.originalReceiptPDFURL
+                        )
                     }
                     VStack(alignment: .leading, spacing: 4) {
                         Text(Strings.saleDetails.newReceipt)
@@ -63,5 +67,6 @@ struct EditSaleView: View {
                     .platformButtonStyle()
                 }
             }
+            .task { await viewModel.refreshSale() }
         }
     }


### PR DESCRIPTION
## Summary
- keep previews of existing images while picking new ones
- show labels for current vs. new images
- defer receipt uploads until save

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688aa2da1ec0832cb004b88c57c7d9f0