### PR TITLE
Fix tap to open sale details

### DIFF
--- a/RoomRoster/Views/InventoryView.swift
+++ b/RoomRoster/Views/InventoryView.swift
@@ -384,6 +384,9 @@ struct InventoryView: View {
                                 }
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .contentShape(Rectangle())
+                                .simultaneousGesture(
+                                    TapGesture().onEnded { HapticManager.shared.impact() }
+                                )
 #endif
                             }
                         }

--- a/RoomRoster/Views/InventoryView.swift
+++ b/RoomRoster/Views/InventoryView.swift
@@ -382,11 +382,9 @@ struct InventoryView: View {
                                         }
                                     }
                                 }
+                                .buttonStyle(.plain)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .contentShape(Rectangle())
-                                .simultaneousGesture(
-                                    TapGesture().onEnded { HapticManager.shared.impact() }
-                                )
 #endif
                             }
                         }

--- a/RoomRoster/Views/SalesView.swift
+++ b/RoomRoster/Views/SalesView.swift
@@ -183,6 +183,9 @@ struct SalesView: View {
                 )
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .contentShape(Rectangle())
+                .simultaneousGesture(
+                    TapGesture().onEnded { HapticManager.shared.impact() }
+                )
 #endif
             }
         }

--- a/RoomRoster/Views/SalesView.swift
+++ b/RoomRoster/Views/SalesView.swift
@@ -181,11 +181,9 @@ struct SalesView: View {
                         }
                     }
                 )
+                .buttonStyle(.plain)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .contentShape(Rectangle())
-                .simultaneousGesture(
-                    TapGesture().onEnded { HapticManager.shared.impact() }
-                )
 #endif
             }
         }


### PR DESCRIPTION
## Summary
- revert change to sale details sheet presentation
- improve row NavigationLink response on iOS

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688cf0fdb760832c8b52ab5d00b56cd7