### PR TITLE
Show signed-in user on Settings screen

### DIFF
--- a/RoomRoster/Utilities/Strings.swift
+++ b/RoomRoster/Utilities/Strings.swift
@@ -220,6 +220,7 @@ struct Strings {
         static let accountSection = "Account"
         static let signInButton = "Sign In"
         static let signOutButton = "Sign Out"
+        static let signedInAs = "Signed in as"
         static let appSettingsSection   = "App Settings"
         static let darkModeToggle       = "Dark Mode"
         static let aboutSection         = "About"

--- a/RoomRoster/Views/SettingsView.swift
+++ b/RoomRoster/Views/SettingsView.swift
@@ -31,6 +31,14 @@ struct SettingsView: View {
             }
             Section(l10n.accountSection) {
                 if auth.isSignedIn {
+                    if let user = auth.userName ?? auth.email {
+                        HStack {
+                            Text(l10n.signedInAs)
+                            Spacer()
+                            Text(user)
+                                .foregroundColor(.secondary)
+                        }
+                    }
                     Button(l10n.signOutButton) {
                         auth.signOut()
                         sheets.signOut()


### PR DESCRIPTION
## Summary
- show the currently signed in user in Settings
- add localization string for the "Signed in as" label

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d3f4a029c832c8b0dc425aab6563b