### PR TITLE
Improve logging and localization

### DIFF
--- a/RoomRoster/Services/FileDownloadService.swift
+++ b/RoomRoster/Services/FileDownloadService.swift
@@ -2,6 +2,7 @@ import Foundation
 
 final class FileDownloadService {
     func download(from url: URL, fileName: String? = nil) async throws -> URL {
+        Logger.network("FileDownloadService-download-\(url.absoluteString)")
         let (data, _) = try await URLSession.shared.data(from: url)
         let fileURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(fileName ?? url.lastPathComponent)

--- a/RoomRoster/Utilities/Strings.swift
+++ b/RoomRoster/Utilities/Strings.swift
@@ -14,10 +14,14 @@ struct Strings {
         static let cancel = "Cancel"
         static let clear = "Clear"
         static let loading = "Loading..."
+        static let uploadingReceipt = "Uploading receipt..."
+        static let receiptPath = "Receipt Path"
+        static let selectPDF = "Select PDF"
     }
 
     // MARK: - MainMenu
     struct mainMenu {
+        static let title = "Menu"
         static let inventory = "Inventory"
         static let sales = "Sales"
         static let reports = "Reports"
@@ -296,5 +300,11 @@ struct Strings {
         static let editSuccess = "Sale updated successfully"
         static let noReceipt = "No Receipt"
         static let failedToUpdate = "Failed to update sale. Please try again."
+    }
+
+    // MARK: - PurchaseReceipt
+    struct purchaseReceipt {
+        static let sectionTitle = "Purchase Receipt"
+        static let saleSectionTitle = "Sale Receipt"
     }
 }

--- a/RoomRoster/Utilities/Strings.swift
+++ b/RoomRoster/Utilities/Strings.swift
@@ -306,5 +306,10 @@ struct Strings {
     struct purchaseReceipt {
         static let sectionTitle = "Purchase Receipt"
         static let saleSectionTitle = "Sale Receipt"
+        struct errors {
+            static func uploadFailed(_ error: String) -> String {
+                "Receipt upload failed: \(error)"
+            }
+        }
     }
 }

--- a/RoomRoster/ViewModels/CreateItemViewModel.swift
+++ b/RoomRoster/ViewModels/CreateItemViewModel.swift
@@ -124,7 +124,7 @@ final class CreateItemViewModel: ObservableObject {
             newItem.purchaseReceiptURL = url.absoluteString
         } catch {
             Logger.log(error, extra: ["description": "Failed to upload receipt image"])
-            receiptUploadError = error.localizedDescription
+            receiptUploadError = Strings.purchaseReceipt.errors.uploadFailed(error.localizedDescription)
             HapticManager.shared.error()
         }
         isUploadingReceipt = false
@@ -140,7 +140,7 @@ final class CreateItemViewModel: ObservableObject {
             newItem.purchaseReceiptURL = saved.absoluteString
         } catch {
             Logger.log(error, extra: ["description": "Failed to upload receipt PDF"])
-            receiptUploadError = error.localizedDescription
+            receiptUploadError = Strings.purchaseReceipt.errors.uploadFailed(error.localizedDescription)
             HapticManager.shared.error()
         }
         isUploadingReceipt = false

--- a/RoomRoster/ViewModels/CreateItemViewModel.swift
+++ b/RoomRoster/ViewModels/CreateItemViewModel.swift
@@ -73,6 +73,7 @@ final class CreateItemViewModel: ObservableObject {
         do {
             rooms = try await roomService.fetchRooms()
         } catch {
+            Logger.log(error, extra: ["description": "Failed to load rooms"])
             errorMessage = l10n.errors.loadRoomsFailed
             HapticManager.shared.error()
         }
@@ -107,6 +108,7 @@ final class CreateItemViewModel: ObservableObject {
             )
             newItem.imageURL = url.absoluteString
         } catch {
+            Logger.log(error, extra: ["description": "Failed to upload image"])
             uploadError = Strings.createItem.errors.imageUpload(error.localizedDescription)
             HapticManager.shared.error()
         }
@@ -121,6 +123,7 @@ final class CreateItemViewModel: ObservableObject {
             let url = try await receiptService.uploadReceipt(image: image, for: newItem.id)
             newItem.purchaseReceiptURL = url.absoluteString
         } catch {
+            Logger.log(error, extra: ["description": "Failed to upload receipt image"])
             receiptUploadError = error.localizedDescription
             HapticManager.shared.error()
         }
@@ -136,6 +139,7 @@ final class CreateItemViewModel: ObservableObject {
             let saved = try await receiptService.uploadReceiptPDF(data, for: newItem.id)
             newItem.purchaseReceiptURL = saved.absoluteString
         } catch {
+            Logger.log(error, extra: ["description": "Failed to upload receipt PDF"])
             receiptUploadError = error.localizedDescription
             HapticManager.shared.error()
         }
@@ -172,6 +176,7 @@ final class CreateItemViewModel: ObservableObject {
             newItem.lastKnownRoom = newRoom
             rooms.append(newRoom)
         } catch {
+            Logger.log(error, extra: ["description": "Failed to add room"])
             newItem.lastKnownRoom = Room.placeholder()
             errorMessage = l10n.errors.addRoomFailed
             HapticManager.shared.error()
@@ -187,6 +192,7 @@ final class CreateItemViewModel: ObservableObject {
             try await inventoryService.createItem(newItem)
             onSave?(newItem)
         } catch {
+            Logger.log(error, extra: ["description": "Failed to save item"])
             errorMessage = l10n.errors.saveFailed
             HapticManager.shared.error()
         }

--- a/RoomRoster/ViewModels/EditItemViewModel.swift
+++ b/RoomRoster/ViewModels/EditItemViewModel.swift
@@ -67,7 +67,7 @@ final class EditItemViewModel: ObservableObject {
             let url = try await receiptService.uploadReceipt(image: image, for: editableItem.id)
             editableItem.purchaseReceiptURL = url.absoluteString
         } catch {
-            receiptUploadError = error.localizedDescription
+            receiptUploadError = Strings.purchaseReceipt.errors.uploadFailed(error.localizedDescription)
             HapticManager.shared.error()
         }
         isUploadingReceipt = false
@@ -81,7 +81,7 @@ final class EditItemViewModel: ObservableObject {
             let saved = try await receiptService.uploadReceiptPDF(data, for: editableItem.id)
             editableItem.purchaseReceiptURL = saved.absoluteString
         } catch {
-            receiptUploadError = error.localizedDescription
+            receiptUploadError = Strings.purchaseReceipt.errors.uploadFailed(error.localizedDescription)
             HapticManager.shared.error()
         }
         isUploadingReceipt = false

--- a/RoomRoster/ViewModels/EditSaleViewModel.swift
+++ b/RoomRoster/ViewModels/EditSaleViewModel.swift
@@ -50,7 +50,7 @@ final class EditSaleViewModel: ObservableObject {
             let url = try await receiptService.uploadReceipt(image: image, for: sale.itemId)
             sale.receiptImageURL = url.absoluteString
         } catch {
-            uploadError = error.localizedDescription
+            uploadError = Strings.purchaseReceipt.errors.uploadFailed(error.localizedDescription)
             HapticManager.shared.error()
         }
         isUploading = false
@@ -64,7 +64,7 @@ final class EditSaleViewModel: ObservableObject {
             let saved = try await receiptService.uploadReceiptPDF(data, for: sale.itemId)
             sale.receiptPDFURL = saved.absoluteString
         } catch {
-            uploadError = error.localizedDescription
+            uploadError = Strings.purchaseReceipt.errors.uploadFailed(error.localizedDescription)
             HapticManager.shared.error()
         }
         isUploading = false

--- a/RoomRoster/Views/CreateItemView.swift
+++ b/RoomRoster/Views/CreateItemView.swift
@@ -217,11 +217,19 @@ struct CreateItemView: View {
                 .platformButtonStyle()
             }
             
-            if let error = viewModel.errorMessage {
-                ErrorBanner(message: error)
-                    .allowsHitTesting(false)
-                    .padding()
+            VStack(spacing: 4) {
+                if let error = viewModel.uploadError {
+                    ErrorBanner(message: error)
+                }
+                if let error = viewModel.receiptUploadError {
+                    ErrorBanner(message: error)
+                }
+                if let error = viewModel.errorMessage {
+                    ErrorBanner(message: error)
+                }
             }
+            .allowsHitTesting(false)
+            .padding()
         }
         .alert(
             l10n.addRoom.title,

--- a/RoomRoster/Views/CreateItemView.swift
+++ b/RoomRoster/Views/CreateItemView.swift
@@ -80,7 +80,7 @@ struct CreateItemView: View {
                     if viewModel.isUploadingReceipt {
                         HStack {
                             ProgressView()
-                            Text("Uploading receipt...")
+                            Text(Strings.general.uploadingReceipt)
                         }
                     }
                     
@@ -91,14 +91,14 @@ struct CreateItemView: View {
                     }
                     
                     HStack {
-                        Text("Receipt Path").foregroundColor(.gray)
+                        Text(Strings.general.receiptPath).foregroundColor(.gray)
                         Spacer()
                         Text(viewModel.newItem.purchaseReceiptURL ?? "")
                             .font(.caption)
                             .multilineTextAlignment(.trailing)
                     }
                 } header: {
-                    Text("Purchase Receipt")
+                    Text(Strings.purchaseReceipt.sectionTitle)
                 }
                 
                 Section {

--- a/RoomRoster/Views/DocumentPickerView.swift
+++ b/RoomRoster/Views/DocumentPickerView.swift
@@ -41,10 +41,11 @@ struct DocumentPickerView: UIViewControllerRepresentable {
 struct PDFPickerButton: View {
     @Binding var url: URL?
     @State private var showPicker = false
-    var label: String = "Select PDF"
+    var label: String = Strings.general.selectPDF
 
     var body: some View {
         Button {
+            HapticManager.shared.impact()
             showPicker = true
         } label: {
             if let url {
@@ -64,10 +65,11 @@ import UniformTypeIdentifiers
 
 struct PDFPickerButton: View {
     @Binding var url: URL?
-    var label: String = "Select PDF"
+    var label: String = Strings.general.selectPDF
 
     var body: some View {
         Button {
+            HapticManager.shared.impact()
             let panel = NSOpenPanel()
             panel.allowedContentTypes = [.pdf]
             panel.allowsMultipleSelection = false

--- a/RoomRoster/Views/EditItemView.swift
+++ b/RoomRoster/Views/EditItemView.swift
@@ -97,7 +97,7 @@ struct EditItemView: View {
                 }
 
                 // MARK: – Purchase Receipt
-                Section(header: Text("Purchase Receipt")) {
+                Section(header: Text(Strings.purchaseReceipt.sectionTitle)) {
                     VStack(alignment: .leading, spacing: 4) {
                         Text(Strings.saleDetails.currentReceipt)
                             .font(.caption)
@@ -115,7 +115,7 @@ struct EditItemView: View {
                     if isUploadingReceipt {
                         HStack {
                             ProgressView()
-                            Text("Uploading receipt...")
+                            Text(Strings.general.uploadingReceipt)
                         }
                     }
                     if let error = receiptUploadError {
@@ -124,7 +124,7 @@ struct EditItemView: View {
                             .font(.caption)
                     }
                     HStack {
-                        Text("Receipt Path").foregroundColor(.gray)
+                        Text(Strings.general.receiptPath).foregroundColor(.gray)
                         Spacer()
                         Text(editableItem.purchaseReceiptURL ?? "")
                             .font(.caption)

--- a/RoomRoster/Views/EditItemView.swift
+++ b/RoomRoster/Views/EditItemView.swift
@@ -371,7 +371,7 @@ struct EditItemView: View {
                 .uploadReceipt(image: image, for: editableItem.id)
             editableItem.purchaseReceiptURL = url.absoluteString
         } catch {
-            receiptUploadError = error.localizedDescription
+            receiptUploadError = Strings.purchaseReceipt.errors.uploadFailed(error.localizedDescription)
             HapticManager.shared.error()
         }
     }
@@ -387,7 +387,7 @@ struct EditItemView: View {
                 .uploadReceiptPDF(data, for: editableItem.id)
             editableItem.purchaseReceiptURL = saved.absoluteString
         } catch {
-            receiptUploadError = error.localizedDescription
+            receiptUploadError = Strings.purchaseReceipt.errors.uploadFailed(error.localizedDescription)
             HapticManager.shared.error()
         }
     }

--- a/RoomRoster/Views/EditItemView.swift
+++ b/RoomRoster/Views/EditItemView.swift
@@ -49,7 +49,8 @@ struct EditItemView: View {
     }
 
     private var content: some View {
-        Form {
+        ZStack(alignment: .bottom) {
+            Form {
                 // MARK: – Photo Section
                 Section(header: Text(l10n.photo.title)) {
                     VStack(alignment: .leading, spacing: 4) {
@@ -268,12 +269,23 @@ struct EditItemView: View {
                     .platformButtonStyle()
                 }
             }
-            .alert(l10n.addRoomAlert.title, isPresented: $showingAddRoomPrompt, actions: {
-                TextField(l10n.addRoomAlert.placeholder, text: $newRoomName)
-                Button(l10n.addRoomAlert.add) {
-                    Task {
-                        if let newRoom = await viewModel.addRoom(name: newRoomName) {
-                            editableItem.lastKnownRoom = newRoom
+            VStack(spacing: 4) {
+                if let error = uploadError {
+                    ErrorBanner(message: error)
+                }
+                if let error = receiptUploadError {
+                    ErrorBanner(message: error)
+                }
+            }
+            .allowsHitTesting(false)
+            .padding()
+        }
+        .alert(l10n.addRoomAlert.title, isPresented: $showingAddRoomPrompt, actions: {
+            TextField(l10n.addRoomAlert.placeholder, text: $newRoomName)
+            Button(l10n.addRoomAlert.add) {
+                Task {
+                    if let newRoom = await viewModel.addRoom(name: newRoomName) {
+                        editableItem.lastKnownRoom = newRoom
                         } else {
                             editableItem.lastKnownRoom = Room.placeholder()
                         }
@@ -290,20 +302,20 @@ struct EditItemView: View {
                     Button(Strings.general.cancel) { close() }
                 }
             }
-            .onAppear {
-                Logger.page("EditItemView")
-                propertyTagInput = editableItem.propertyTag?.rawValue ?? ""
-                if let parsed = Date.fromShortString(editableItem.dateAdded) {
-                    dateAddedDate = parsed
-                }
+        .onAppear {
+            Logger.page("EditItemView")
+            propertyTagInput = editableItem.propertyTag?.rawValue ?? ""
+            if let parsed = Date.fromShortString(editableItem.dateAdded) {
+                dateAddedDate = parsed
             }
-            .task {
-                await viewModel.fetchInventory()
-            }
-            .task {
-                await viewModel.loadRooms()
-            }
-            }
+        }
+        .task {
+            await viewModel.fetchInventory()
+        }
+        .task {
+            await viewModel.loadRooms()
+        }
+    }
 
     private func validateTag() {
         if propertyTagInput.isEmpty || propertyTagInput == editableItem.propertyTag?.label {

--- a/RoomRoster/Views/EditSaleView.swift
+++ b/RoomRoster/Views/EditSaleView.swift
@@ -20,7 +20,7 @@ struct EditSaleView: View {
 
     private var content: some View {
         Form {
-                Section("Sale Receipt") {
+                Section(Strings.purchaseReceipt.saleSectionTitle) {
                     VStack(alignment: .leading, spacing: 4) {
                         Text(Strings.saleDetails.currentReceipt)
                             .font(.caption)
@@ -42,7 +42,7 @@ struct EditSaleView: View {
                     if viewModel.isUploading {
                         HStack {
                             ProgressView()
-                            Text("Uploading receipt...")
+                            Text(Strings.general.uploadingReceipt)
                         }
                     }
                     if let error = viewModel.uploadError {

--- a/RoomRoster/Views/EditSaleView.swift
+++ b/RoomRoster/Views/EditSaleView.swift
@@ -10,11 +10,16 @@ struct EditSaleView: View {
     var body: some View {
         content
             .navigationTitle(Strings.saleDetails.editTitle)
-            .overlay {
-                if let saveError {
-                    VStack { Spacer(); ErrorBanner(message: saveError) }
-                        .allowsHitTesting(false)
+            .overlay(alignment: .bottom) {
+                VStack(spacing: 4) {
+                    if let error = viewModel.uploadError {
+                        ErrorBanner(message: error)
+                    }
+                    if let saveError {
+                        ErrorBanner(message: saveError)
+                    }
                 }
+                .allowsHitTesting(false)
             }
     }
 

--- a/RoomRoster/Views/ImagePickerView.swift
+++ b/RoomRoster/Views/ImagePickerView.swift
@@ -60,6 +60,7 @@ struct CombinedImagePickerButton: View {
     var body: some View {
         Button {
             Logger.action("Selected Image Picker")
+            HapticManager.shared.impact()
             showSourceDialog = true
         } label: {
             if let img = image {
@@ -75,11 +76,13 @@ struct CombinedImagePickerButton: View {
         .confirmationDialog(l10n.dialog.title, isPresented: $showSourceDialog) {
             if UIImagePickerController.isSourceTypeAvailable(.camera) {
                 Button(l10n.dialog.capture) {
+                    HapticManager.shared.impact()
                     sourceType = .camera
                     showPicker = true
                 }
             }
             Button(l10n.dialog.library) {
+                HapticManager.shared.impact()
                 sourceType = .photoLibrary
                 showPicker = true
             }
@@ -109,12 +112,14 @@ struct CombinedImagePickerButton: View {
                 Label(l10n.title, systemImage: "photo.on.rectangle")
             }
         }
+        .onTapGesture { HapticManager.shared.impact() }
         .onChange(of: selection) { newItem in
             guard let newItem else { return }
             Task {
                 if let data = try? await newItem.loadTransferable(type: Data.self),
                    let platform = PlatformImage(data: data) {
                     image = platform
+                    HapticManager.shared.success()
                 }
             }
         }

--- a/RoomRoster/Views/ItemDetailsView.swift
+++ b/RoomRoster/Views/ItemDetailsView.swift
@@ -70,7 +70,7 @@ struct ItemDetailsView: View {
                     }
 
                     if item.purchaseReceiptURL != nil {
-                        Text("Purchase Receipt")
+                        Text(Strings.purchaseReceipt.sectionTitle)
                             .font(.headline)
                         ReceiptImageView(urlString: item.purchaseReceiptURL)
                     }

--- a/RoomRoster/Views/MainMenuView.swift
+++ b/RoomRoster/Views/MainMenuView.swift
@@ -74,7 +74,7 @@ struct MainMenuView: View {
             if useSplitView {
                 NavigationSplitView {
                     menuList
-                        .navigationTitle("Menu")
+                        .navigationTitle(Strings.mainMenu.title)
                 } detail: {
                     detailView(for: coordinator.selectedTab)
                 }


### PR DESCRIPTION
## Summary
- localize more strings and banner titles
- log failures when uploading rooms or receipts
- add haptics for document and image pickers
- log download operations

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688d3e84ef48832c82fd9d509560d746