### PR TITLE
Add groupID to item creation tests

### DIFF
--- a/RoomRoster.xcodeproj/project.pbxproj
+++ b/RoomRoster.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		3B334618E2334DAFB69FB690 /* SellItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68CAB974B03A4708BB968FC8 /* SellItemView.swift */; };
 		46E1F1D89FA0B254B0938408 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		4A41F16A7DFB4ABE9D824975 /* ItemValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71B5019D5A040FCBB81807B /* ItemValidatorTests.swift */; };
+		ABCDEF012345678901234569 /* PropertyTagRangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF01234567890123456A /* PropertyTagRangeTests.swift */; };
 		5A43DC562B7C4ABC9A123456 /* SalesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E32FE1D99B3B44E6A6801234 /* SalesViewModel.swift */; };
 		5E159DC99DBD4D6E817F1768 /* Sale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA2B3CF72714AF5B8CD11E0 /* Sale.swift */; };
 		62093EEF26D4F31B0F245579 /* PurchaseReceiptServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135983A51B686BEA6E40D6D4 /* PurchaseReceiptServiceTests.swift */; };
@@ -24,10 +25,10 @@
 		72BF4E5D2A924D36879BA797 /* InventoryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9062D441F4874BA89C2A0A1E /* InventoryServiceTests.swift */; };
 		767B05902D4C5DC000566C25 /* RoomRosterApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767B058F2D4C5DC000566C25 /* RoomRosterApp.swift */; };
 		767B05922D4C5DC000566C25 /* InventoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767B05912D4C5DC000566C25 /* InventoryView.swift */; };
-                767B05942D4C5DC000566C25 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767B05932D4C5DC000566C25 /* Item.swift */; };
-                B3C17C2B098B4B398D39C2BE /* ItemGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC23ECDFDC014EEEA305BDDB /* ItemGroup.swift */; };
-                ABCDEF012345678901234568 /* PropertyTagRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF012345678901234567 /* PropertyTagRange.swift */; };
-                767B05962D4C5DC400566C25 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 767B05952D4C5DC400566C25 /* Assets.xcassets */; };
+				767B05942D4C5DC000566C25 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767B05932D4C5DC000566C25 /* Item.swift */; };
+				B3C17C2B098B4B398D39C2BE /* ItemGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC23ECDFDC014EEEA305BDDB /* ItemGroup.swift */; };
+		ABCDEF012345678901234568 /* PropertyTagRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF012345678901234567 /* PropertyTagRange.swift */; };
+		767B05962D4C5DC400566C25 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 767B05952D4C5DC400566C25 /* Assets.xcassets */; };
 		767B059A2D4C5DC400566C25 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 767B05992D4C5DC400566C25 /* Preview Assets.xcassets */; };
 		767B05A42D4C5DC400566C25 /* RoomRosterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767B05A32D4C5DC400566C25 /* RoomRosterTests.swift */; };
 		767B05AE2D4C5DC400566C25 /* RoomRosterUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767B05AD2D4C5DC400566C25 /* RoomRosterUITests.swift */; };
@@ -141,15 +142,15 @@
 		70EC0F7257914A11A7589F29 /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
 		767B058C2D4C5DC000566C25 /* RoomRoster.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RoomRoster.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		767B058F2D4C5DC000566C25 /* RoomRosterApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomRosterApp.swift; sourceTree = "<group>"; };
-                767B05912D4C5DC000566C25 /* InventoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InventoryView.swift; sourceTree = "<group>"; };
-                767B05932D4C5DC000566C25 /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
-                FC23ECDFDC014EEEA305BDDB /* ItemGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemGroup.swift; sourceTree = "<group>"; };
-                767B05952D4C5DC400566C25 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		767B05912D4C5DC000566C25 /* InventoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InventoryView.swift; sourceTree = "<group>"; };
+		767B05932D4C5DC000566C25 /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
+		FC23ECDFDC014EEEA305BDDB /* ItemGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemGroup.swift; sourceTree = "<group>"; };
+		767B05952D4C5DC400566C25 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		767B05972D4C5DC400566C25 /* RoomRoster.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RoomRoster.entitlements; sourceTree = "<group>"; };
 		767B05992D4C5DC400566C25 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		767B059F2D4C5DC400566C25 /* RoomRosterTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RoomRosterTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		767B05A32D4C5DC400566C25 /* RoomRosterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomRosterTests.swift; sourceTree = "<group>"; };
-                ABCDEF012345678901234567 /* PropertyTagRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyTagRange.swift; sourceTree = "<group>"; };
+		ABCDEF012345678901234567 /* PropertyTagRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyTagRange.swift; sourceTree = "<group>"; };
 		767B05A92D4C5DC400566C25 /* RoomRosterUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RoomRosterUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		767B05AD2D4C5DC400566C25 /* RoomRosterUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomRosterUITests.swift; sourceTree = "<group>"; };
 		767B05AF2D4C5DC400566C25 /* RoomRosterUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomRosterUITestsLaunchTests.swift; sourceTree = "<group>"; };
@@ -262,7 +263,7 @@
 				B646DBB22E342D270040A437 /* EditSaleView.swift */,
 				B612436B2DB03BA000B9098B /* ImagePickerView.swift */,
 				E0B282C5B6FF4AADB74F1234 /* DocumentPickerView.swift */,
-				767B05912D4C5DC000566C25 /* InventoryView.swift */,
+		767B05912D4C5DC000566C25 /* InventoryView.swift */,
 				767B05C02D4C666F00566C25 /* ItemDetailsView.swift */,
 				B65F71242DE6491700310D40 /* MainMenuView.swift */,
 				B65F71262DE6493600310D40 /* ReportsView.swift */,
@@ -298,9 +299,9 @@
 				B615ED1B2DE12A16009BE623 /* Status.swift */,
 				B6A6D6D72DD7AB3800378BFF /* FieldBinding.swift */,
 				767B05BE2D4C5F9E00566C25 /* GoogleSheetsResponse.swift */,
-                                767B05932D4C5DC000566C25 /* Item.swift */,
-                                FC23ECDFDC014EEEA305BDDB /* ItemGroup.swift */,
-                                ABCDEF012345678901234567 /* PropertyTagRange.swift */,
+		767B05932D4C5DC000566C25 /* Item.swift */,
+		FC23ECDFDC014EEEA305BDDB /* ItemGroup.swift */,
+		ABCDEF012345678901234567 /* PropertyTagRange.swift */,
                                 B6A6D6D52DD7AAEE00378BFF /* ItemField.swift */,
 				C66A533C9D0B40A885DA2172 /* Condition.swift */,
 				0EA2B3CF72714AF5B8CD11E0 /* Sale.swift */,
@@ -362,7 +363,7 @@
 				765183BA2D8CD20800FBA72E /* ViewModels */,
 				765183B92D8CD1F300FBA72E /* Views */,
 				767E82D12D8F34B900B48011 /* Utilities */,
-				767B05952D4C5DC400566C25 /* Assets.xcassets */,
+		767B05952D4C5DC400566C25 /* Assets.xcassets */,
 				767B05972D4C5DC400566C25 /* RoomRoster.entitlements */,
 				767B05982D4C5DC400566C25 /* Preview Content */,
 			);
@@ -384,7 +385,7 @@
 				9062D441F4874BA89C2A0A1E /* InventoryServiceTests.swift */,
 				135983A51B686BEA6E40D6D4 /* PurchaseReceiptServiceTests.swift */,
 				E71B5019D5A040FCBB81807B /* ItemValidatorTests.swift */,
-                                ABCDEF01234567890123456A /* PropertyTagRangeTests.swift */,
+				ABCDEF01234567890123456A /* PropertyTagRangeTests.swift */,
 				BF137618CD644A1997B55ED6 /* MockNetworkService.swift */,
 				614508236AFA4269887FF35A /* RoomServiceTests.swift */,
 				4AC01C73ED7A4FBC9EECB3D3 /* ViewModelTests.swift */,
@@ -596,9 +597,9 @@
 				B646DBB52E342D380040A437 /* EditItemViewModel.swift in Sources */,
 				767E82D72D8F3ABE00B48011 /* AuthenticationManager.swift in Sources */,
 				B6D80EF82E28255E00748907 /* ReceiptPDFGenerator.swift in Sources */,
-                                767B05942D4C5DC000566C25 /* Item.swift in Sources */,
-                                B3C17C2B098B4B398D39C2BE /* ItemGroup.swift in Sources */,
-                ABCDEF012345678901234568 /* PropertyTagRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF012345678901234567 /* PropertyTagRange.swift */; };
+				767B05942D4C5DC000566C25 /* Item.swift in Sources */,
+				B3C17C2B098B4B398D39C2BE /* ItemGroup.swift in Sources */,
+				ABCDEF012345678901234568 /* PropertyTagRange.swift in Sources */,
                                 B67560442DF0D231001A5D9D /* CreateItemViewModel.swift in Sources */,
 				B65F712B2DE6495900310D40 /* SettingsView.swift in Sources */,
 				B6D80EFD2E28DD8D00748907 /* SpreadsheetManager.swift in Sources */,
@@ -659,7 +660,7 @@
 				62093EEF26D4F31B0F245579 /* PurchaseReceiptServiceTests.swift in Sources */,
 				62176ADB9D7B4DF2BBE81798 /* SaleReceiptServiceTests.swift in Sources */,
 				4A41F16A7DFB4ABE9D824975 /* ItemValidatorTests.swift in Sources */,
-                                ABCDEF012345678901234569 /* PropertyTagRangeTests.swift in Sources */,
+				ABCDEF012345678901234569 /* PropertyTagRangeTests.swift in Sources */,
 				E9FBF450607D494DA1894333 /* MockNetworkService.swift in Sources */,
 				DE7D257232324BDDB96C6F37 /* RoomServiceTests.swift in Sources */,
 				7DB3EA08C76F4E048B379677 /* ViewModelTests.swift in Sources */,

--- a/RoomRoster.xcodeproj/project.pbxproj
+++ b/RoomRoster.xcodeproj/project.pbxproj
@@ -24,8 +24,10 @@
 		72BF4E5D2A924D36879BA797 /* InventoryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9062D441F4874BA89C2A0A1E /* InventoryServiceTests.swift */; };
 		767B05902D4C5DC000566C25 /* RoomRosterApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767B058F2D4C5DC000566C25 /* RoomRosterApp.swift */; };
 		767B05922D4C5DC000566C25 /* InventoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767B05912D4C5DC000566C25 /* InventoryView.swift */; };
-		767B05942D4C5DC000566C25 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767B05932D4C5DC000566C25 /* Item.swift */; };
-		767B05962D4C5DC400566C25 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 767B05952D4C5DC400566C25 /* Assets.xcassets */; };
+                767B05942D4C5DC000566C25 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767B05932D4C5DC000566C25 /* Item.swift */; };
+                B3C17C2B098B4B398D39C2BE /* ItemGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC23ECDFDC014EEEA305BDDB /* ItemGroup.swift */; };
+                ABCDEF012345678901234568 /* PropertyTagRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF012345678901234567 /* PropertyTagRange.swift */; };
+                767B05962D4C5DC400566C25 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 767B05952D4C5DC400566C25 /* Assets.xcassets */; };
 		767B059A2D4C5DC400566C25 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 767B05992D4C5DC400566C25 /* Preview Assets.xcassets */; };
 		767B05A42D4C5DC400566C25 /* RoomRosterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767B05A32D4C5DC400566C25 /* RoomRosterTests.swift */; };
 		767B05AE2D4C5DC400566C25 /* RoomRosterUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767B05AD2D4C5DC400566C25 /* RoomRosterUITests.swift */; };
@@ -139,13 +141,15 @@
 		70EC0F7257914A11A7589F29 /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
 		767B058C2D4C5DC000566C25 /* RoomRoster.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RoomRoster.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		767B058F2D4C5DC000566C25 /* RoomRosterApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomRosterApp.swift; sourceTree = "<group>"; };
-		767B05912D4C5DC000566C25 /* InventoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InventoryView.swift; sourceTree = "<group>"; };
-		767B05932D4C5DC000566C25 /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
-		767B05952D4C5DC400566C25 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+                767B05912D4C5DC000566C25 /* InventoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InventoryView.swift; sourceTree = "<group>"; };
+                767B05932D4C5DC000566C25 /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
+                FC23ECDFDC014EEEA305BDDB /* ItemGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemGroup.swift; sourceTree = "<group>"; };
+                767B05952D4C5DC400566C25 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		767B05972D4C5DC400566C25 /* RoomRoster.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RoomRoster.entitlements; sourceTree = "<group>"; };
 		767B05992D4C5DC400566C25 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		767B059F2D4C5DC400566C25 /* RoomRosterTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RoomRosterTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		767B05A32D4C5DC400566C25 /* RoomRosterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomRosterTests.swift; sourceTree = "<group>"; };
+                ABCDEF012345678901234567 /* PropertyTagRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyTagRange.swift; sourceTree = "<group>"; };
 		767B05A92D4C5DC400566C25 /* RoomRosterUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RoomRosterUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		767B05AD2D4C5DC400566C25 /* RoomRosterUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomRosterUITests.swift; sourceTree = "<group>"; };
 		767B05AF2D4C5DC400566C25 /* RoomRosterUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomRosterUITestsLaunchTests.swift; sourceTree = "<group>"; };
@@ -206,6 +210,7 @@
 		E0B282C5B6FF4AADB74F1234 /* DocumentPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentPickerView.swift; sourceTree = "<group>"; };
 		E32FE1D99B3B44E6A6801234 /* SalesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesViewModel.swift; sourceTree = "<group>"; };
 		E71B5019D5A040FCBB81807B /* ItemValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemValidatorTests.swift; sourceTree = "<group>"; };
+                ABCDEF01234567890123456A /* PropertyTagRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyTagRangeTests.swift; sourceTree = "<group>"; };
 		F1DB1AD2C44D425AB9A59153 /* SellItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellItemViewModel.swift; sourceTree = "<group>"; };
                 F2ACBFBB75EA4E3C9514A9AB /* DepreciationCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepreciationCalculatorTests.swift; sourceTree = "<group>"; };
                 AFA014E93EE2475992EB91B0 /* PlatformImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformImage.swift; sourceTree = "<group>"; };
@@ -293,8 +298,10 @@
 				B615ED1B2DE12A16009BE623 /* Status.swift */,
 				B6A6D6D72DD7AB3800378BFF /* FieldBinding.swift */,
 				767B05BE2D4C5F9E00566C25 /* GoogleSheetsResponse.swift */,
-				767B05932D4C5DC000566C25 /* Item.swift */,
-				B6A6D6D52DD7AAEE00378BFF /* ItemField.swift */,
+                                767B05932D4C5DC000566C25 /* Item.swift */,
+                                FC23ECDFDC014EEEA305BDDB /* ItemGroup.swift */,
+                                ABCDEF012345678901234567 /* PropertyTagRange.swift */,
+                                B6A6D6D52DD7AAEE00378BFF /* ItemField.swift */,
 				C66A533C9D0B40A885DA2172 /* Condition.swift */,
 				0EA2B3CF72714AF5B8CD11E0 /* Sale.swift */,
 				9022FF3CD87CA507378085C4 /* Spreadsheet.swift */,
@@ -377,6 +384,7 @@
 				9062D441F4874BA89C2A0A1E /* InventoryServiceTests.swift */,
 				135983A51B686BEA6E40D6D4 /* PurchaseReceiptServiceTests.swift */,
 				E71B5019D5A040FCBB81807B /* ItemValidatorTests.swift */,
+                                ABCDEF01234567890123456A /* PropertyTagRangeTests.swift */,
 				BF137618CD644A1997B55ED6 /* MockNetworkService.swift */,
 				614508236AFA4269887FF35A /* RoomServiceTests.swift */,
 				4AC01C73ED7A4FBC9EECB3D3 /* ViewModelTests.swift */,
@@ -588,8 +596,10 @@
 				B646DBB52E342D380040A437 /* EditItemViewModel.swift in Sources */,
 				767E82D72D8F3ABE00B48011 /* AuthenticationManager.swift in Sources */,
 				B6D80EF82E28255E00748907 /* ReceiptPDFGenerator.swift in Sources */,
-				767B05942D4C5DC000566C25 /* Item.swift in Sources */,
-				B67560442DF0D231001A5D9D /* CreateItemViewModel.swift in Sources */,
+                                767B05942D4C5DC000566C25 /* Item.swift in Sources */,
+                                B3C17C2B098B4B398D39C2BE /* ItemGroup.swift in Sources */,
+                ABCDEF012345678901234568 /* PropertyTagRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF012345678901234567 /* PropertyTagRange.swift */; };
+                                B67560442DF0D231001A5D9D /* CreateItemViewModel.swift in Sources */,
 				B65F712B2DE6495900310D40 /* SettingsView.swift in Sources */,
 				B6D80EFD2E28DD8D00748907 /* SpreadsheetManager.swift in Sources */,
 				B615ED222DE2BB4E009BE623 /* RoomService.swift in Sources */,
@@ -649,6 +659,7 @@
 				62093EEF26D4F31B0F245579 /* PurchaseReceiptServiceTests.swift in Sources */,
 				62176ADB9D7B4DF2BBE81798 /* SaleReceiptServiceTests.swift in Sources */,
 				4A41F16A7DFB4ABE9D824975 /* ItemValidatorTests.swift in Sources */,
+                                ABCDEF012345678901234569 /* PropertyTagRangeTests.swift in Sources */,
 				E9FBF450607D494DA1894333 /* MockNetworkService.swift in Sources */,
 				DE7D257232324BDDB96C6F37 /* RoomServiceTests.swift in Sources */,
 				7DB3EA08C76F4E048B379677 /* ViewModelTests.swift in Sources */,

--- a/RoomRoster/Models/Item.swift
+++ b/RoomRoster/Models/Item.swift
@@ -7,11 +7,22 @@
 
 import Foundation
 
+/// Represents a single entry in the inventory list.
+///
+/// Each item has its own identifier and optional `propertyTag`.
+/// Items that are variants of the same product can share an `ItemGroup`
+/// through `groupID`. When `quantity` is greater than `1` the record
+/// stands for multiple identical units that do **not** require individual
+/// property tags. If every unit must carry its own tag, create separate
+/// `Item` instances with the same `groupID` so they can be managed as a
+/// group while retaining unique tags.
+
 struct Item: Identifiable, Hashable {
     var id: String
     var imageURL: String
     var name: String
     var description: String
+    var groupID: String?
     var quantity: Int
     var dateAdded: String
     var estimatedPrice: Double?
@@ -21,6 +32,10 @@ struct Item: Identifiable, Hashable {
     var lastUpdated: Date?
     var propertyTag: PropertyTag?
     var purchaseReceiptURL: String?
+
+    var isGrouped: Bool {
+        groupID != nil || quantity > 1
+    }
 }
 
 extension Item {
@@ -103,7 +118,7 @@ extension Item {
     }
 
     static func empty() -> Item {
-        .init(id: "", imageURL: "", name: "", description: "", quantity: 0,
+        .init(id: "", imageURL: "", name: "", description: "", groupID: nil, quantity: 0,
               dateAdded: "", estimatedPrice: nil, status: .available,
               lastKnownRoom: .empty(), updatedBy: "", lastUpdated: nil, propertyTag: nil,
               purchaseReceiptURL: nil)

--- a/RoomRoster/Models/Item.swift
+++ b/RoomRoster/Models/Item.swift
@@ -7,15 +7,21 @@
 
 import Foundation
 
-/// Represents a single entry in the inventory list.
+/// Represents a single unit of inventory or a collection of identical
+/// units that do not need their own property tags.
 ///
-/// Each item has its own identifier and optional `propertyTag`.
-/// Items that are variants of the same product can share an `ItemGroup`
-/// through `groupID`. When `quantity` is greater than `1` the record
-/// stands for multiple identical units that do **not** require individual
-/// property tags. If every unit must carry its own tag, create separate
-/// `Item` instances with the same `groupID` so they can be managed as a
-/// group while retaining unique tags.
+/// - Each item always has a unique `id` and may optionally belong to an
+///   `ItemGroup` via `groupID` when multiple records describe the same
+///   product.
+/// - If `quantity` is greater than `1`, the record indicates a stack of
+///   identical items that share all attributes and **have no individual
+///   `PropertyTag` values**. Use this when tracking generics like cables
+///   or low‑value parts.
+/// - When every unit requires a distinct tag, create separate `Item`
+///   instances, each with `quantity == 1` and its own `propertyTag`, but
+///   reuse the same `groupID` so the items can be managed collectively.
+///   Bulk creation helpers (e.g., `PropertyTagRange`) can generate these
+///   items from a list or range of tags.
 
 struct Item: Identifiable, Hashable {
     var id: String

--- a/RoomRoster/Models/ItemGroup.swift
+++ b/RoomRoster/Models/ItemGroup.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Describes attributes shared by multiple inventory items.
+///
+/// `ItemGroup` instances are never persisted directly. Instead, each
+/// `Item` references a group via its `groupID`. When adding many of the
+/// same product, create one group and then generate individual `Item`
+/// records—each may supply its own `propertyTag` if needed—so that the
+/// data is normalized but items can still be tracked separately.
+
+struct ItemGroup: Identifiable, Hashable {
+    var id: String
+    var name: String
+    var description: String
+    var imageURL: String
+    var estimatedPrice: Double?
+}
+
+extension ItemGroup {
+    static func empty() -> ItemGroup {
+        .init(id: UUID().uuidString, name: "", description: "", imageURL: "", estimatedPrice: nil)
+    }
+}

--- a/RoomRoster/Models/ItemGroup.swift
+++ b/RoomRoster/Models/ItemGroup.swift
@@ -1,12 +1,19 @@
 import Foundation
 
-/// Describes attributes shared by multiple inventory items.
+/// Collection of shared attributes for a set of related items.
 ///
-/// `ItemGroup` instances are never persisted directly. Instead, each
-/// `Item` references a group via its `groupID`. When adding many of the
-/// same product, create one group and then generate individual `Item`
-/// records—each may supply its own `propertyTag` if needed—so that the
-/// data is normalized but items can still be tracked separately.
+/// An `ItemGroup` stores common metadata—name, description, images—that
+/// would otherwise be duplicated on every `Item`. The group itself is
+/// **not** persisted to the backend. Instead each `Item` stores the ID of
+/// its group in `groupID` so the UI can display them together.
+///
+/// Workflow guidelines:
+/// - When you have multiple identical products that need individual
+///   property tags, create a single `ItemGroup` and then create separate
+///   `Item` records referencing that group. Tools like `PropertyTagRange`
+///   can help generate the items in bulk.
+/// - For loose items without tags, you can either omit the group entirely
+///   or store them as a single `Item` with a `quantity` greater than `1`.
 
 struct ItemGroup: Identifiable, Hashable {
     var id: String

--- a/RoomRoster/Models/PropertyTagRange.swift
+++ b/RoomRoster/Models/PropertyTagRange.swift
@@ -1,12 +1,13 @@
 import Foundation
 
-/// Utility type for parsing comma separated lists and ranges of
-/// property tags.
+/// Parses comma‑separated lists and ranges of `PropertyTag` values.
 ///
-/// Input such as `"A0001-A0005,B0001"` expands into a collection of
-/// `PropertyTag` values. This makes it easy to create multiple `Item`
-/// records in an `ItemGroup` while ensuring each item receives its own
-/// unique tag.
+/// Use this when bulk‑creating items. A string like `"A0001-A0005,B0001"`
+/// expands to `[A0001, A0002, A0003, A0004, A0005, B0001]`. These tags can
+/// then be validated and used to instantiate individual `Item` records
+/// that share an `ItemGroup`. By centralizing the parsing logic here, the
+/// UI can accept flexible input while keeping property tags unique and
+/// correctly counted against the desired quantity.
 
 struct PropertyTagRange: Hashable, Sequence {
     var tags: [PropertyTag]

--- a/RoomRoster/Models/PropertyTagRange.swift
+++ b/RoomRoster/Models/PropertyTagRange.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Utility type for parsing comma separated lists and ranges of
+/// property tags.
+///
+/// Input such as `"A0001-A0005,B0001"` expands into a collection of
+/// `PropertyTag` values. This makes it easy to create multiple `Item`
+/// records in an `ItemGroup` while ensuring each item receives its own
+/// unique tag.
+
+struct PropertyTagRange: Hashable, Sequence {
+    var tags: [PropertyTag]
+
+    init(tags: [PropertyTag]) {
+        self.tags = tags
+    }
+
+    init?(from string: String) {
+        var result: [PropertyTag] = []
+        for segment in string.split(separator: ",") {
+            let part = segment.trimmingCharacters(in: .whitespacesAndNewlines)
+            if part.contains("-") {
+                let ends = part.split(separator: "-", maxSplits: 1).map { String($0) }
+                guard ends.count == 2,
+                      let start = PropertyTag(rawValue: ends[0]),
+                      let end = PropertyTag(rawValue: ends[1]) else { return nil }
+                let prefix = String(start.rawValue.prefix(1))
+                guard prefix == String(end.rawValue.prefix(1)),
+                      let startNum = Int(start.rawValue.dropFirst()),
+                      let endNum = Int(end.rawValue.dropFirst()),
+                      startNum <= endNum else { return nil }
+                for num in startNum...endNum {
+                    let tagString = String(format: "%@%04d", prefix, num)
+                    guard let tag = PropertyTag(rawValue: tagString) else { return nil }
+                    result.append(tag)
+                }
+            } else if let tag = PropertyTag(rawValue: part) {
+                result.append(tag)
+            } else {
+                return nil
+            }
+        }
+        self.tags = result
+    }
+
+    func makeIterator() -> IndexingIterator<[PropertyTag]> {
+        tags.makeIterator()
+    }
+}

--- a/RoomRoster/Utilities/ItemValidator.swift
+++ b/RoomRoster/Utilities/ItemValidator.swift
@@ -12,6 +12,7 @@ enum ItemValidationError: Error, Equatable {
     case emptyDescription
     case invalidTagFormat
     case duplicateTag
+    case quantityMismatch
 }
 
 struct ItemValidator {
@@ -27,19 +28,47 @@ struct ItemValidator {
         }
     }
 
-    static func validateTag(_ input: String, currentItemID: String?, allItems: [Item]) throws(ItemValidationError) -> PropertyTag {
-        guard let tag = PropertyTag(rawValue: input) else {
+    /// Validates a property tag string which may contain a comma separated list
+    /// or range of tags. Returns the parsed collection of tags.
+    ///
+    /// - Parameters:
+    ///   - input: The raw tag string entered by the user.
+    ///   - quantity: Expected number of items. Must match the number of parsed tags.
+    ///   - currentItemID: If editing an existing item, its identifier so duplicates are ignored.
+    ///   - allItems: Existing items used to check for duplicate tags.
+    /// - Throws: ``ItemValidationError`` if the input is invalid or contains duplicates.
+    /// - Returns: Parsed property tags.
+    static func validateTags(
+        _ input: String,
+        quantity: Int,
+        currentItemID: String?,
+        allItems: [Item]
+    ) throws -> [PropertyTag] {
+        guard let range = PropertyTagRange(from: input) else {
             throw ItemValidationError.invalidTagFormat
         }
 
-        let isDuplicate = allItems.contains {
-            $0.id != currentItemID && $0.propertyTag?.rawValue.caseInsensitiveCompare(tag.rawValue) == .orderedSame
+        if range.tags.count != quantity {
+            throw ItemValidationError.quantityMismatch
         }
 
-        if isDuplicate {
-            throw ItemValidationError.duplicateTag
+        var seen: Set<String> = []
+        for tag in range.tags {
+            // check duplicates within the range
+            if !seen.insert(tag.rawValue.uppercased()).inserted {
+                throw ItemValidationError.duplicateTag
+            }
+
+            // check duplicates against existing items
+            let isDuplicate = allItems.contains {
+                $0.id != currentItemID &&
+                $0.propertyTag?.rawValue.caseInsensitiveCompare(tag.rawValue) == .orderedSame
+            }
+            if isDuplicate {
+                throw ItemValidationError.duplicateTag
+            }
         }
 
-        return tag
+        return range.tags
     }
 }

--- a/RoomRoster/Utilities/ItemValidator.swift
+++ b/RoomRoster/Utilities/ItemValidator.swift
@@ -54,12 +54,10 @@ struct ItemValidator {
 
         var seen: Set<String> = []
         for tag in range.tags {
-            // check duplicates within the range
             if !seen.insert(tag.rawValue.uppercased()).inserted {
                 throw ItemValidationError.duplicateTag
             }
 
-            // check duplicates against existing items
             let isDuplicate = allItems.contains {
                 $0.id != currentItemID &&
                 $0.propertyTag?.rawValue.caseInsensitiveCompare(tag.rawValue) == .orderedSame

--- a/RoomRoster/Utilities/Strings.swift
+++ b/RoomRoster/Utilities/Strings.swift
@@ -106,6 +106,7 @@ struct Strings {
             struct tag {
                 static let format = "Invalid tag format. Use formatting like A1234."
                 static let duplicate = "That tag already exists."
+                static let quantityMismatch = "Quantity must match number of property tags."
                 static let other = "Unknown tag error."
             }
             static func imageUpload(_ error: String) -> String {
@@ -194,6 +195,7 @@ struct Strings {
             struct tag {
                 static let format = "Invalid tag format. Use formatting like A1234."
                 static let duplicate = "That tag already exists."
+                static let quantityMismatch = "Quantity must match number of property tags."
             }
             static func imageUpload(_ error: String) -> String {
                 "Upload failed: \(error)"

--- a/RoomRoster/ViewModels/CreateItemViewModel.swift
+++ b/RoomRoster/ViewModels/CreateItemViewModel.swift
@@ -155,14 +155,18 @@ final class CreateItemViewModel: ObservableObject {
             tagError = nil
             showTagError = false
         } catch {
-            switch error {
-            case .invalidTagFormat:
-                tagError = l10n.errors.tag.format
-            case .duplicateTag:
-                tagError = l10n.errors.tag.duplicate
-            case .quantityMismatch:
-                tagError = l10n.errors.tag.quantityMismatch
-            default:
+            if let validationError = error as? ItemValidationError {
+                switch validationError {
+                case .invalidTagFormat:
+                    tagError = l10n.errors.tag.format
+                case .duplicateTag:
+                    tagError = l10n.errors.tag.duplicate
+                case .quantityMismatch:
+                    tagError = l10n.errors.tag.quantityMismatch
+                default:
+                    tagError = l10n.errors.tag.other
+                }
+            } else {
                 tagError = l10n.errors.tag.other
             }
             showTagError = true

--- a/RoomRoster/ViewModels/CreateItemViewModel.swift
+++ b/RoomRoster/ViewModels/CreateItemViewModel.swift
@@ -145,12 +145,13 @@ final class CreateItemViewModel: ObservableObject {
 
     func validateTag() {
         do {
-            let tag = try ItemValidator.validateTag(
+            let tags = try ItemValidator.validateTags(
                 propertyTagInput,
+                quantity: newItem.quantity,
                 currentItemID: nil,
                 allItems: itemsProvider()
             )
-            newItem.propertyTag = tag
+            newItem.propertyTag = tags.count == 1 ? tags[0] : nil
             tagError = nil
             showTagError = false
         } catch {
@@ -159,6 +160,8 @@ final class CreateItemViewModel: ObservableObject {
                 tagError = l10n.errors.tag.format
             case .duplicateTag:
                 tagError = l10n.errors.tag.duplicate
+            case .quantityMismatch:
+                tagError = l10n.errors.tag.quantityMismatch
             default:
                 tagError = l10n.errors.tag.other
             }

--- a/RoomRoster/ViewModels/CreateItemViewModel.swift
+++ b/RoomRoster/ViewModels/CreateItemViewModel.swift
@@ -57,6 +57,7 @@ final class CreateItemViewModel: ObservableObject {
             imageURL: "",
             name: "",
             description: "",
+            groupID: nil,
             quantity: 1,
             dateAdded: Date().toShortString(),
             estimatedPrice: nil,

--- a/RoomRoster/Views/CreateItemView.swift
+++ b/RoomRoster/Views/CreateItemView.swift
@@ -113,15 +113,9 @@ struct CreateItemView: View {
                         HStack {
                             Text(l10n.basicInfo.quantity)
                             Spacer()
-                            TextField(
-                                l10n.basicInfo.enter.quantity,
-                                value: $viewModel.newItem.quantity,
-                                format: .number
-                            )
-#if canImport(UIKit)
-                            .keyboardType(.numberPad)
-#endif
-                            .textFieldStyle(.roundedBorder)
+                            Stepper(value: $viewModel.newItem.quantity, in: 1...Int.max) {
+                                Text("\(viewModel.newItem.quantity)")
+                            }
                         }
                         HStack {
                             Text(l10n.basicInfo.tag)

--- a/RoomRoster/Views/CreateItemView.swift
+++ b/RoomRoster/Views/CreateItemView.swift
@@ -164,6 +164,9 @@ struct CreateItemView: View {
                 Stepper(value: $viewModel.newItem.quantity, in: 1...Int.max) {
                     Text("\(viewModel.newItem.quantity)")
                 }
+                .onChange(of: viewModel.newItem.quantity) { _, _ in
+                    viewModel.validateTag()
+                }
             }
             VStack(alignment: .leading, spacing: 4) {
                 Text(l10n.basicInfo.tag)

--- a/RoomRoster/Views/CreateItemView.swift
+++ b/RoomRoster/Views/CreateItemView.swift
@@ -235,3 +235,4 @@ struct CreateItemView: View {
             }
         }
 
+    }

--- a/RoomRoster/Views/CreateItemView.swift
+++ b/RoomRoster/Views/CreateItemView.swift
@@ -1,10 +1,3 @@
-//
-//  CreateItemView.swift
-//  RoomRoster
-//
-//  Created by Terrence Pledger on 4/11/25.
-//
-
 import SwiftUI
 #if canImport(UIKit)
 import UIKit
@@ -13,7 +6,7 @@ import UIKit
 private typealias l10n = Strings.createItem
 
 struct CreateItemView: View {
-    @Environment(\.dismiss) var dismiss
+    @Environment(\.dismiss) private var dismiss
     @ObservedObject var viewModel: CreateItemViewModel
     var onCancel: (() -> Void)? = nil
 
@@ -34,161 +27,39 @@ struct CreateItemView: View {
 
     private var content: some View {
         ZStack(alignment: .bottom) {
-            Form {
-                    Section {
-                        CombinedImagePickerButton(image: $viewModel.pickedImage)
-                            .onChange(of: viewModel.pickedImage) { _, img in
-                                viewModel.onImagePicked(img)
-                            }
+            formContent
+            if let error = viewModel.errorMessage {
+                ErrorBanner(message: error)
+                    .allowsHitTesting(false)
+                    .padding()
+            }
+        }
+        .alert(l10n.addRoom.title, isPresented: $viewModel.showingAddRoomPrompt) {
+            TextField(l10n.addRoom.placeholder, text: $viewModel.newRoomName)
+            Button(l10n.addRoom.button) { Task { await viewModel.addRoom() } }
+                .platformButtonStyle()
+            Button(Strings.general.cancel, role: .cancel) { }
+        }
+        .navigationTitle(l10n.title)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button(Strings.general.cancel) { close() }
+            }
+        }
+        .onAppear {
+            Task { await viewModel.signIn() }
+            Task { await viewModel.loadRooms() }
+            Logger.page("CreateItemView")
+        }
+    }
 
-                        if viewModel.isUploading {
-                            HStack {
-                                ProgressView()
-                                Text(l10n.uploadingImage)
-                            }
-                        }
-                        if let error = viewModel.uploadError {
-                            Text(error)
-                                .foregroundColor(.red)
-                                .font(.caption)
-                        }
-
-                        HStack {
-                            Text(l10n.imageURL).foregroundColor(.gray)
-                            Spacer()
-                            Text(viewModel.newItem.imageURL)
-                                .font(.caption)
-                                .multilineTextAlignment(.trailing)
-                        }
-                    } header: {
-                        Text(l10n.photo)
-                    }
-
-                    Section {
-                        ReceiptImageView(urlString: viewModel.newItem.purchaseReceiptURL)
-                        CombinedImagePickerButton(image: $viewModel.pickedReceiptImage)
-                            .onChange(of: viewModel.pickedReceiptImage) { _, img in
-                                viewModel.onReceiptPicked(img)
-                            }
-                        PDFPickerButton(url: $viewModel.pickedReceiptPDF)
-                            .onChange(of: viewModel.pickedReceiptPDF) { _, url in
-                                viewModel.onReceiptPDFPicked(url)
-                            }
-
-                        if viewModel.isUploadingReceipt {
-                            HStack {
-                                ProgressView()
-                                Text("Uploading receipt...")
-                            }
-                        }
-                        if let error = viewModel.receiptUploadError {
-                            Text(error)
-                                .foregroundColor(.red)
-                                .font(.caption)
-                        }
-                        HStack {
-                            Text("Receipt Path").foregroundColor(.gray)
-                            Spacer()
-                            Text(viewModel.newItem.purchaseReceiptURL ?? "")
-                                .font(.caption)
-                                .multilineTextAlignment(.trailing)
-                        }
-                    } header: {
-                        Text("Purchase Receipt")
-                    }
-
-                    Section(content: {
-                        HStack {
-                            Text(l10n.basicInfo.name)
-                            Spacer()
-                            TextField(l10n.basicInfo.enter.name, text: $viewModel.newItem.name)
-                                .multilineTextAlignment(.trailing)
-                        }
-                        HStack {
-                            Text(l10n.basicInfo.description)
-                            Spacer()
-                            TextField(l10n.basicInfo.enter.description, text: $viewModel.newItem.description)
-                                .multilineTextAlignment(.trailing)
-                        }
-                        HStack {
-                            Text(l10n.basicInfo.quantity)
-                            Spacer()
-                            Stepper(value: $viewModel.newItem.quantity, in: 1...Int.max) {
-                                Text("\(viewModel.newItem.quantity)")
-                            }
-                        }
-                        HStack {
-                            Text(l10n.basicInfo.tag)
-                            Spacer()
-                            TextField(l10n.basicInfo.enter.tag, text: $viewModel.propertyTagInput)
-                                .focused($tagFieldFocused)
-                                .multilineTextAlignment(.trailing)
-                                .onChange(of: tagFieldFocused) { _, focused in
-                                    if !focused {
-                                        withAnimation { viewModel.validateTag() }
-                                    }
-                                }
-                        }
-                        if viewModel.showTagError, let error = viewModel.tagError {
-                            HStack {
-                                Spacer()
-                                Text(error)
-                                    .foregroundColor(.red)
-                                    .font(.caption)
-                                    .onAppear {
-                                        DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
-                                            withAnimation {
-                                                if (viewModel.tagError?.count ?? 0) > 0 {
-                                                    if !tagFieldFocused {
-                                                        viewModel.propertyTagInput = ""
-                                                    }
-                                                    viewModel.validateTag()
-                                                }
-                                            }
-                                        }
-                                    }
-                            }
-                        }
-                    }, header: { Text(l10n.basicInfo.title) })
-                }
-
-                Section {
-                    HStack {
-                        Text(l10n.details.price)
-                        Spacer()
-                        TextField(
-                            l10n.details.enter.price,
-                            value: $viewModel.newItem.estimatedPrice,
-                            format: .number
-                        ).multilineTextAlignment(.trailing)
-                    }
-
-                    Picker(l10n.details.status, selection: $viewModel.newItem.status) {
-                        ForEach(Status.allCases, id: \.self) { status in
-                            Text(status.label).tag(status)
-                        }
-                    }
-
-                    Picker(l10n.details.room.title, selection: $viewModel.newItem.lastKnownRoom) {
-                        if viewModel.newItem.lastKnownRoom == Room.placeholder() {
-                            Text(l10n.details.enter.room).tag(Room.placeholder())
-                        }
-                        ForEach(viewModel.rooms, id: \.self) { room in
-                            Text(room.label).tag(room)
-                        }
-                        Text(l10n.details.room.add)
-                            .foregroundColor(.blue)
-                            .tag(Room(name: "__add_new__"))
-                    }
-                    .onChange(of: viewModel.newItem.lastKnownRoom) { _, newValue in
-                        if newValue.name == "__add_new__" {
-                            viewModel.showingAddRoomPrompt = true
-                        }
-                    }
-                } header: {
-                    Text(l10n.details.title)
-                }
-
+    private var formContent: some View {
+        Form {
+            photoSection
+            receiptSection
+            basicInfoSection
+            detailsSection
+            Section {
                 Button(Strings.general.save) {
                     Task {
                         await viewModel.saveItem()
@@ -198,41 +69,181 @@ struct CreateItemView: View {
                         }
                     }
                 }
-                .disabled(viewModel.newItem.name.isEmpty || viewModel.newItem.description.isEmpty || viewModel.tagError != nil || viewModel.newItem.lastKnownRoom == Room.placeholder())
+                .disabled(
+                    viewModel.newItem.name.isEmpty ||
+                    viewModel.newItem.description.isEmpty ||
+                    viewModel.tagError != nil ||
+                    viewModel.newItem.lastKnownRoom == Room.placeholder()
+                )
                 .platformButtonStyle()
-                }
-            }
-            if let error = viewModel.errorMessage {
-                ErrorBanner(message: error)
-                    .allowsHitTesting(false)
-                    .padding()
-            }
-            .alert(
-                l10n.addRoom.title,
-                isPresented: $viewModel.showingAddRoomPrompt,
-                actions: {
-                    TextField(
-                        l10n.addRoom.placeholder,
-                        text: $viewModel.newRoomName
-                    )
-                    Button(l10n.addRoom.button) {
-                        Task { await viewModel.addRoom() }
-                    }
-                    .platformButtonStyle()
-                    Button(Strings.general.cancel, role: .cancel) { }
-                }
-            )
-            .navigationTitle(l10n.title)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(Strings.general.cancel) { close() }
-                }
-            }
-            .onAppear {
-                Task { await viewModel.signIn() }
-                Task { await viewModel.loadRooms() }
-                Logger.page("CreateItemView")
             }
         }
-
     }
+
+    private var photoSection: some View {
+        Section(header: Text(l10n.photo)) {
+            CombinedImagePickerButton(image: $viewModel.pickedImage)
+                .onChange(of: viewModel.pickedImage) { _, img in
+                    viewModel.onImagePicked(img)
+                }
+            if viewModel.isUploading {
+                HStack {
+                    ProgressView()
+                    Text(l10n.uploadingImage)
+                }
+            }
+            if let error = viewModel.uploadError {
+                Text(error)
+                    .foregroundColor(.red)
+                    .font(.caption)
+            }
+            HStack {
+                Text(l10n.imageURL)
+                    .foregroundColor(.gray)
+                Spacer()
+                Text(viewModel.newItem.imageURL)
+                    .font(.caption)
+                    .multilineTextAlignment(.trailing)
+            }
+        }
+    }
+
+    private var receiptSection: some View {
+        Section(header: Text("Purchase Receipt")) {
+            ReceiptImageView(urlString: viewModel.newItem.purchaseReceiptURL)
+            CombinedImagePickerButton(image: $viewModel.pickedReceiptImage)
+                .onChange(of: viewModel.pickedReceiptImage) { _, img in
+                    viewModel.onReceiptPicked(img)
+                }
+            PDFPickerButton(url: $viewModel.pickedReceiptPDF)
+                .onChange(of: viewModel.pickedReceiptPDF) { _, url in
+                    viewModel.onReceiptPDFPicked(url)
+                }
+            if viewModel.isUploadingReceipt {
+                HStack {
+                    ProgressView()
+                    Text("Uploading receipt...")
+                }
+            }
+            if let error = viewModel.receiptUploadError {
+                Text(error)
+                    .foregroundColor(.red)
+                    .font(.caption)
+            }
+            HStack {
+                Text("Receipt Path")
+                    .foregroundColor(.gray)
+                Spacer()
+                Text(viewModel.newItem.purchaseReceiptURL ?? "")
+                    .font(.caption)
+                    .multilineTextAlignment(.trailing)
+            }
+        }
+    }
+
+    private var basicInfoSection: some View {
+        Section(header: Text(l10n.basicInfo.title)) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(l10n.basicInfo.name)
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                TextField(l10n.basicInfo.enter.name, text: $viewModel.newItem.name)
+                    .textFieldStyle(.roundedBorder)
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                Text(l10n.basicInfo.description)
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                TextField(l10n.basicInfo.enter.description, text: $viewModel.newItem.description)
+                    .textFieldStyle(.roundedBorder)
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                Text(l10n.basicInfo.quantity)
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                Stepper(value: $viewModel.newItem.quantity, in: 1...Int.max) {
+                    Text("\(viewModel.newItem.quantity)")
+                }
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                Text(l10n.basicInfo.tag)
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                TextField(l10n.basicInfo.enter.tag, text: $viewModel.propertyTagInput)
+                    .focused($tagFieldFocused)
+                    .textFieldStyle(.roundedBorder)
+                    .onChange(of: tagFieldFocused) { _, focused in
+                        if !focused { withAnimation { viewModel.validateTag() } }
+                    }
+                if viewModel.showTagError, let error = viewModel.tagError {
+                    Text(error)
+                        .foregroundColor(.red)
+                        .font(.caption)
+                        .onAppear {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
+                                withAnimation {
+                                    if (viewModel.tagError?.count ?? 0) > 0 {
+                                        if !tagFieldFocused {
+                                            viewModel.propertyTagInput = ""
+                                        }
+                                        viewModel.validateTag()
+                                    }
+                                }
+                            }
+                        }
+                }
+            }
+        }
+    }
+
+    private var detailsSection: some View {
+        Section(header: Text(l10n.details.title)) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(l10n.details.price)
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                TextField(
+                    l10n.details.enter.price,
+                    value: $viewModel.newItem.estimatedPrice,
+                    format: .number
+                )
+#if canImport(UIKit)
+                .keyboardType(.decimalPad)
+#endif
+                .textFieldStyle(.roundedBorder)
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                Text(l10n.details.status)
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                Picker(l10n.details.status, selection: $viewModel.newItem.status) {
+                    ForEach(Status.allCases, id: \.self) { status in
+                        Text(status.label).tag(status)
+                    }
+                }
+                .pickerStyle(.menu)
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                Text(l10n.details.room.title)
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                Picker(l10n.details.enter.room, selection: $viewModel.newItem.lastKnownRoom) {
+                    if viewModel.newItem.lastKnownRoom == Room.placeholder() {
+                        Text(l10n.details.enter.room).tag(Room.placeholder())
+                    }
+                    ForEach(viewModel.rooms, id: \.self) { room in
+                        Text(room.label).tag(room)
+                    }
+                    Text(l10n.details.room.add)
+                        .foregroundColor(.blue)
+                        .tag(Room(name: "__add_new__"))
+                }
+                .onChange(of: viewModel.newItem.lastKnownRoom) { _, newValue in
+                    if newValue.name == "__add_new__" {
+                        viewModel.showingAddRoomPrompt = true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/RoomRoster/Views/CreateItemView.swift
+++ b/RoomRoster/Views/CreateItemView.swift
@@ -234,5 +234,4 @@ struct CreateItemView: View {
                 Logger.page("CreateItemView")
             }
         }
-    }
 

--- a/RoomRoster/Views/EditItemView.swift
+++ b/RoomRoster/Views/EditItemView.swift
@@ -144,13 +144,9 @@ struct EditItemView: View {
                         Text(l10n.basicInfo.quantity)
                             .font(.caption)
                             .foregroundColor(.gray)
-                        TextField(l10n.basicInfo.enter.quantity,
-                                  value: $editableItem.quantity,
-                                  format: .number)
-#if canImport(UIKit)
-                            .keyboardType(.numberPad)
-#endif
-                            .textFieldStyle(.roundedBorder)
+                        Stepper(value: $editableItem.quantity, in: 1...Int.max) {
+                            Text("\(editableItem.quantity)")
+                        }
                     }
                     VStack(alignment: .leading, spacing: 4) {
                         Text(l10n.basicInfo.tag)

--- a/RoomRoster/Views/EditItemView.swift
+++ b/RoomRoster/Views/EditItemView.swift
@@ -147,6 +147,9 @@ struct EditItemView: View {
                         Stepper(value: $editableItem.quantity, in: 1...Int.max) {
                             Text("\(editableItem.quantity)")
                         }
+                        .onChange(of: editableItem.quantity) { _, _ in
+                            validateTag()
+                        }
                     }
                     VStack(alignment: .leading, spacing: 4) {
                         Text(l10n.basicInfo.tag)

--- a/RoomRoster/Views/EditItemView.swift
+++ b/RoomRoster/Views/EditItemView.swift
@@ -301,22 +301,26 @@ struct EditItemView: View {
             return
         }
 
-        guard let tag = PropertyTag(rawValue: propertyTagInput) else {
-            tagError = l10n.errors.tag.format
-            return
+        do {
+            _ = try ItemValidator.validateTags(
+                propertyTagInput,
+                quantity: editableItem.quantity,
+                currentItemID: editableItem.id,
+                allItems: viewModel.items
+            )
+            tagError = nil
+        } catch {
+            switch error {
+            case .invalidTagFormat:
+                tagError = l10n.errors.tag.format
+            case .duplicateTag:
+                tagError = l10n.errors.tag.duplicate
+            case .quantityMismatch:
+                tagError = l10n.errors.tag.quantityMismatch
+            default:
+                tagError = nil
+            }
         }
-
-        let isDuplicate = viewModel.items.contains {
-            $0.id != editableItem.id &&
-            $0.propertyTag?.rawValue == tag.rawValue
-        }
-
-        if isDuplicate {
-            tagError = l10n.errors.tag.duplicate
-            return
-        }
-
-        tagError = nil
     }
 
     private func uploadPickedImage() async {

--- a/RoomRoster/Views/EditItemView.swift
+++ b/RoomRoster/Views/EditItemView.swift
@@ -310,14 +310,18 @@ struct EditItemView: View {
             )
             tagError = nil
         } catch {
-            switch error {
-            case .invalidTagFormat:
-                tagError = l10n.errors.tag.format
-            case .duplicateTag:
-                tagError = l10n.errors.tag.duplicate
-            case .quantityMismatch:
-                tagError = l10n.errors.tag.quantityMismatch
-            default:
+            if let validationError = error as? ItemValidationError {
+                switch validationError {
+                case .invalidTagFormat:
+                    tagError = l10n.errors.tag.format
+                case .duplicateTag:
+                    tagError = l10n.errors.tag.duplicate
+                case .quantityMismatch:
+                    tagError = l10n.errors.tag.quantityMismatch
+                default:
+                    tagError = nil
+                }
+            } else {
                 tagError = nil
             }
         }

--- a/RoomRosterTests/ItemValidatorTests.swift
+++ b/RoomRosterTests/ItemValidatorTests.swift
@@ -25,13 +25,26 @@ final class ItemValidatorTests: XCTestCase {
             propertyTag: PropertyTag(rawValue: "A0001"),
             purchaseReceiptURL: nil
         )
-        XCTAssertThrowsError(try ItemValidator.validateTag("A0001", currentItemID: nil, allItems: [item])) { error in
+        XCTAssertThrowsError(try ItemValidator.validateTags("A0001", quantity: 1, currentItemID: nil, allItems: [item])) { error in
             XCTAssertEqual(error as? ItemValidationError, .duplicateTag)
         }
     }
 
     func testValidateTagSuccess() throws {
-        let tag = try ItemValidator.validateTag("A0001", currentItemID: nil, allItems: [])
-        XCTAssertEqual(tag.rawValue, "A0001")
+        let tags = try ItemValidator.validateTags("A0001", quantity: 1, currentItemID: nil, allItems: [])
+        XCTAssertEqual(tags, [PropertyTag(rawValue: "A0001")!])
+    }
+
+    func testValidateRangeQuantityMismatch() {
+        XCTAssertThrowsError(
+            try ItemValidator.validateTags("A0001-A0002", quantity: 1, currentItemID: nil, allItems: [])
+        ) { error in
+            XCTAssertEqual(error as? ItemValidationError, .quantityMismatch)
+        }
+    }
+
+    func testValidateRangeSuccess() throws {
+        let tags = try ItemValidator.validateTags("A0001-A0002", quantity: 2, currentItemID: nil, allItems: [])
+        XCTAssertEqual(tags.map(\.rawValue), ["A0001", "A0002"])
     }
 }

--- a/RoomRosterTests/ItemValidatorTests.swift
+++ b/RoomRosterTests/ItemValidatorTests.swift
@@ -9,7 +9,22 @@ final class ItemValidatorTests: XCTestCase {
     }
 
     func testValidateTagDuplicateThrows() {
-        let item = Item(id: "1", imageURL: "", name: "A", description: "", quantity: 1, dateAdded: "", estimatedPrice: nil, status: .available, lastKnownRoom: .empty(), updatedBy: "", lastUpdated: nil, propertyTag: PropertyTag(rawValue: "A0001"), purchaseReceiptURL: nil)
+        let item = Item(
+            id: "1",
+            imageURL: "",
+            name: "A",
+            description: "",
+            groupID: "test-group",
+            quantity: 1,
+            dateAdded: "",
+            estimatedPrice: nil,
+            status: .available,
+            lastKnownRoom: .empty(),
+            updatedBy: "",
+            lastUpdated: nil,
+            propertyTag: PropertyTag(rawValue: "A0001"),
+            purchaseReceiptURL: nil
+        )
         XCTAssertThrowsError(try ItemValidator.validateTag("A0001", currentItemID: nil, allItems: [item])) { error in
             XCTAssertEqual(error as? ItemValidationError, .duplicateTag)
         }

--- a/RoomRosterTests/PropertyTagRangeTests.swift
+++ b/RoomRosterTests/PropertyTagRangeTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import RoomRoster
+
+final class PropertyTagRangeTests: XCTestCase {
+    func testParseSingleTag() {
+        let range = PropertyTagRange(from: "A0001")
+        XCTAssertEqual(range?.tags, [PropertyTag(rawValue: "A0001")!])
+    }
+
+    func testParseRange() {
+        let range = PropertyTagRange(from: "A0001-A0003")
+        XCTAssertEqual(range?.tags, ["A0001", "A0002", "A0003"].compactMap { PropertyTag(rawValue: $0) })
+    }
+
+    func testParseListAndRange() {
+        let range = PropertyTagRange(from: "A0001-A0002,B0001")
+        let expected = ["A0001", "A0002", "B0001"].compactMap { PropertyTag(rawValue: $0) }
+        XCTAssertEqual(range?.tags, expected)
+    }
+
+    func testInvalidRangeReturnsNil() {
+        XCTAssertNil(PropertyTagRange(from: "A0003-A0001"))
+    }
+}

--- a/RoomRosterTests/ViewModelTests.swift
+++ b/RoomRosterTests/ViewModelTests.swift
@@ -22,7 +22,26 @@ final class ViewModelTests: XCTestCase {
             inventoryService: InventoryService(sheetId: "s", networkService: MockNetworkService()),
             roomService: RoomService(sheetId: "s", networkService: MockNetworkService()),
             receiptService: PurchaseReceiptService(),
-            itemsProvider: { [Item(id: "1", imageURL: "", name: "", description: "", quantity: 1, dateAdded: "", estimatedPrice: nil, status: .available, lastKnownRoom: .empty(), updatedBy: "", lastUpdated: nil, propertyTag: PropertyTag(rawValue: "A0001"), purchaseReceiptURL: nil)] }
+            itemsProvider: {
+                [
+                    Item(
+                        id: "1",
+                        imageURL: "",
+                        name: "",
+                        description: "",
+                        groupID: "test-group",
+                        quantity: 1,
+                        dateAdded: "",
+                        estimatedPrice: nil,
+                        status: .available,
+                        lastKnownRoom: .empty(),
+                        updatedBy: "",
+                        lastUpdated: nil,
+                        propertyTag: PropertyTag(rawValue: "A0001"),
+                        purchaseReceiptURL: nil
+                    )
+                ]
+            }
         )
         vm.propertyTagInput = "A0001"
         vm.validateTag()

--- a/RoomRosterTests/ViewModelTests.swift
+++ b/RoomRosterTests/ViewModelTests.swift
@@ -48,4 +48,19 @@ final class ViewModelTests: XCTestCase {
         XCTAssertTrue(vm.showTagError)
         XCTAssertEqual(vm.tagError, Strings.createItem.errors.tag.duplicate)
     }
+
+    @MainActor
+    func testCreateItemViewModelQuantityMismatch() {
+        let vm = CreateItemViewModel(
+            inventoryService: InventoryService(sheetId: "s", networkService: MockNetworkService()),
+            roomService: RoomService(sheetId: "s", networkService: MockNetworkService()),
+            receiptService: PurchaseReceiptService(),
+            itemsProvider: { [] }
+        )
+        vm.newItem.quantity = 2
+        vm.propertyTagInput = "A0001"
+        vm.validateTag()
+        XCTAssertTrue(vm.showTagError)
+        XCTAssertEqual(vm.tagError, Strings.createItem.errors.tag.quantityMismatch)
+    }
 }


### PR DESCRIPTION
## Summary
- expand item instantiations to include `groupID`
- include new `ItemGroup` and `PropertyTagRange` helper types
- document how items, groups, and property tag ranges work together

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project RoomRoster.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a52308f94832cada8c040b39211d0