### PR TITLE
Add cancel option in EditItemView

### DIFF
--- a/RoomRoster/Views/EditItemView.swift
+++ b/RoomRoster/Views/EditItemView.swift
@@ -267,6 +267,9 @@ struct EditItemView: View {
                     }
                     .disabled(editableItem.name.isEmpty || editableItem.description.isEmpty || tagError != nil)
                     .platformButtonStyle()
+
+                    Button(Strings.general.cancel) { close() }
+                        .platformButtonStyle()
                 }
             }
             VStack(spacing: 4) {
@@ -308,12 +311,6 @@ struct EditItemView: View {
             if let parsed = Date.fromShortString(editableItem.dateAdded) {
                 dateAddedDate = parsed
             }
-        }
-        .task {
-            await viewModel.fetchInventory()
-        }
-        .task {
-            await viewModel.loadRooms()
         }
     }
 


### PR DESCRIPTION
## Summary
- let users back out of editing from the form with a Cancel button
- remove background refresh logic from EditItemView

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688d575ad054832cb6d71ff2fc50da67