### PR TITLE
Fix inventory log loading before sign-in

### DIFF
--- a/RoomRoster/Views/InventoryView.swift
+++ b/RoomRoster/Views/InventoryView.swift
@@ -124,7 +124,7 @@ struct InventoryView: View {
             Logger.page("InventoryView")
         }
         .task {
-            guard sheets.currentSheet != nil else { return }
+            guard auth.isSignedIn, sheets.currentSheet != nil else { return }
             await viewModel.fetchInventory()
             await viewModel.loadRecentLogs(for: viewModel.items)
 #if os(macOS)
@@ -136,7 +136,7 @@ struct InventoryView: View {
 #endif
         }
         .refreshable {
-            guard sheets.currentSheet != nil else { return }
+            guard auth.isSignedIn, sheets.currentSheet != nil else { return }
             await viewModel.fetchInventory()
             await viewModel.loadRecentLogs(for: viewModel.items)
 #if os(macOS)


### PR DESCRIPTION
## Summary
- ensure inventory logs are loaded only after authentication succeeds

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d75258ce4832ca5eb2e2f22e6bf48