### PR TITLE
Use stepper for mac quantity input

### DIFF
--- a/RoomRoster/Views/CreateItemView.swift
+++ b/RoomRoster/Views/CreateItemView.swift
@@ -112,6 +112,11 @@ struct CreateItemView: View {
                     HStack {
                         Text(l10n.basicInfo.quantity)
                         Spacer()
+#if os(macOS)
+                        Stepper(value: $viewModel.newItem.quantity, in: 1...Int.max) {
+                            Text("\(viewModel.newItem.quantity)")
+                        }
+#else
                         TextField(
                             l10n.basicInfo.enter.quantity,
                             value: $viewModel.newItem.quantity,
@@ -121,6 +126,10 @@ struct CreateItemView: View {
                         .keyboardType(.numberPad)
 #endif
                         .textFieldStyle(.roundedBorder)
+#endif
+                    }
+                    .onChange(of: viewModel.newItem.quantity) { _, _ in
+                        viewModel.validateTag()
                     }
                     
                     HStack {


### PR DESCRIPTION
## Summary
- replace mac quantity text field with stepper and validate tag on change

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d753bc838832c9bb8da314d8f677b