### PR TITLE
Refine Mac form layout and navigation

### DIFF
--- a/RoomRoster/Views/Components/ReceiptImageView.swift
+++ b/RoomRoster/Views/Components/ReceiptImageView.swift
@@ -11,22 +11,32 @@ struct ReceiptImageView: View {
                 switch phase {
                 case .success(let image):
                     image.resizable()
-                         .scaledToFit()
-                         .frame(height: 120)
-                         .cornerRadius(8)
+                        .scaledToFit()
+                        .frame(height: 120)
+                        .cornerRadius(8)
                 case .failure:
-                    Image(systemName: "xmark.octagon").foregroundColor(.red)
+                    Image(systemName: "xmark.octagon")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(height: 120)
+                        .foregroundColor(.red.opacity(0.8))
                 default:
-                    ProgressView().frame(height: 120)
+                    Image(systemName: "photo")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(height: 120)
+                        .foregroundColor(.secondary.opacity(0.5))
                 }
             }
         } else if let urlString, !urlString.isEmpty {
             Label("View Receipt", systemImage: "doc")
                 .foregroundColor(.blue)
         } else {
-            Text(Strings.saleDetails.noReceipt)
-                .foregroundColor(.secondary)
-                .font(.caption)
+            Image(systemName: "photo")
+                .resizable()
+                .scaledToFit()
+                .frame(height: 120)
+                .foregroundColor(.secondary.opacity(0.5))
         }
     }
 }

--- a/RoomRoster/Views/SalesDetailsView.swift
+++ b/RoomRoster/Views/SalesDetailsView.swift
@@ -13,10 +13,17 @@ struct SalesDetailsView: View {
     @State private var shareURL: URL?
     @State private var errorMessage: String?
     @State private var editSuccess: String?
-    @State private var showEdit = false
     private let downloader = FileDownloadService()
 
     var body: some View {
+#if os(macOS)
+        NavigationStack { content }
+#else
+        content
+#endif
+    }
+
+    private var content: some View {
         List {
             Section {
                 row(l10n.date, sale.date.toShortString())
@@ -78,16 +85,9 @@ struct SalesDetailsView: View {
         }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
-#if os(macOS)
-                Button(l10n.editButton) { showEdit = true }
-#else
-                NavigationLink { editSaleView } label: { Text(l10n.editButton) }
-#endif
+                NavigationLink(l10n.editButton) { editSaleView }
             }
         }
-#if os(macOS)
-        .sheet(isPresented: $showEdit) { editSaleView }
-#endif
         .sheet(item: $shareURL) { url in
             ShareSheet(activityItems: [url])
         }


### PR DESCRIPTION
## Summary
- Streamlined create item form for macOS with native `LabeledContent` fields and an aligned quantity stepper.
- Added robust placeholder handling for images and receipts to avoid empty states.
- Integrated sale editing directly into the details pane using navigation instead of a modal sheet.

## Testing
- `swift test` *(fails: Could not find Package.swift)*


------
https://chatgpt.com/codex/tasks/task_e_688e3bb3d848832ca0a95e361ee2ec61