### PR TITLE
Fix macOS edit sale navigation and room picker

### DIFF
--- a/RoomRoster/ViewModels/CreateItemViewModel.swift
+++ b/RoomRoster/ViewModels/CreateItemViewModel.swift
@@ -72,6 +72,7 @@ final class CreateItemViewModel: ObservableObject {
 
     func loadRooms() async {
         do {
+            await AuthenticationManager.shared.ensureSignedIn()
             rooms = try await roomService.fetchRooms()
         } catch {
             if (error as? URLError)?.code == .cancelled || error is CancellationError {

--- a/RoomRoster/ViewModels/CreateItemViewModel.swift
+++ b/RoomRoster/ViewModels/CreateItemViewModel.swift
@@ -70,20 +70,6 @@ final class CreateItemViewModel: ObservableObject {
 
     }
 
-    func loadRooms() async {
-        do {
-            await AuthenticationManager.shared.ensureSignedIn()
-            rooms = try await roomService.fetchRooms()
-        } catch {
-            if (error as? URLError)?.code == .cancelled || error is CancellationError {
-                return
-            }
-            Logger.log(error, extra: ["description": "Failed to load rooms"])
-            errorMessage = l10n.errors.loadRoomsFailed
-            HapticManager.shared.error()
-        }
-    }
-
     func onImagePicked(_ image: PlatformImage?) {
         pickedImage = image
         guard let image else { return }
@@ -212,9 +198,5 @@ final class CreateItemViewModel: ObservableObject {
             errorMessage = l10n.errors.saveFailed
             HapticManager.shared.error()
         }
-    }
-
-    func signIn() async {
-        await AuthenticationManager.shared.signIn()
     }
 }

--- a/RoomRoster/Views/CreateItemView.swift
+++ b/RoomRoster/Views/CreateItemView.swift
@@ -354,11 +354,10 @@ struct CreateItemView: View {
                 Button(Strings.general.cancel) { close() }
             }
         }
+        .task {
+            await viewModel.loadRooms()
+        }
         .onAppear {
-            Task {
-                await viewModel.signIn()
-                await viewModel.loadRooms()
-            }
             Logger.page("CreateItemView")
         }
     }

--- a/RoomRoster/Views/CreateItemView.swift
+++ b/RoomRoster/Views/CreateItemView.swift
@@ -264,7 +264,7 @@ struct CreateItemView: View {
                         }
                         .frame(width: fieldWidth)
                         .padding(.trailing, 4)
-                        .onChange(of: viewModel.newItem.lastKnownRoom) { _, newValue in
+                        .onChange(of: viewModel.newItem.lastKnownRoom) { newValue in
                             if newValue.name == "__add_new__" {
                                 viewModel.showingAddRoomPrompt = true
                             }

--- a/RoomRoster/Views/CreateItemView.swift
+++ b/RoomRoster/Views/CreateItemView.swift
@@ -34,6 +34,7 @@ struct CreateItemView: View {
                 }
                 .allowsHitTesting(false)
             }
+            .task { await viewModel.loadRooms() }
 #else
         NavigationStack { content }
             .macSheetFrame()
@@ -44,6 +45,7 @@ struct CreateItemView: View {
                 }
                 .allowsHitTesting(false)
             }
+            .task { await viewModel.loadRooms() }
 #endif
     }
 

--- a/RoomRoster/Views/CreateItemView.swift
+++ b/RoomRoster/Views/CreateItemView.swift
@@ -355,8 +355,10 @@ struct CreateItemView: View {
             }
         }
         .onAppear {
-            Task { await viewModel.signIn() }
-            Task { await viewModel.loadRooms() }
+            Task {
+                await viewModel.signIn()
+                await viewModel.loadRooms()
+            }
             Logger.page("CreateItemView")
         }
     }

--- a/RoomRoster/Views/InventoryView.swift
+++ b/RoomRoster/Views/InventoryView.swift
@@ -103,6 +103,7 @@ struct InventoryView: View {
                     }
                 )
             )
+            .environmentObject(viewModel)
         }
 #endif
         .toolbar {
@@ -125,6 +126,7 @@ struct InventoryView: View {
         }
         .task {
             guard auth.isSignedIn, sheets.currentSheet != nil else { return }
+            await viewModel.loadRooms()
             await viewModel.fetchInventory()
             await viewModel.loadRecentLogs(for: viewModel.items)
 #if os(macOS)
@@ -137,6 +139,7 @@ struct InventoryView: View {
         }
         .refreshable {
             guard auth.isSignedIn, sheets.currentSheet != nil else { return }
+            await viewModel.loadRooms()
             await viewModel.fetchInventory()
             await viewModel.loadRecentLogs(for: viewModel.items)
 #if os(macOS)
@@ -155,6 +158,7 @@ struct InventoryView: View {
         .onChange(of: auth.isSignedIn) { signedIn in
             if signedIn, sheets.currentSheet != nil {
                 Task {
+                    await viewModel.loadRooms()
                     await viewModel.fetchInventory()
                     await viewModel.loadRecentLogs(for: viewModel.items)
                 }
@@ -163,6 +167,7 @@ struct InventoryView: View {
         .onChange(of: sheets.currentSheet?.id) { sheetID in
             if sheetID != nil, auth.isSignedIn {
                 Task {
+                    await viewModel.loadRooms()
                     await viewModel.fetchInventory()
                     await viewModel.loadRecentLogs(for: viewModel.items)
                 }
@@ -215,6 +220,7 @@ struct InventoryView: View {
                 ),
                 onCancel: { pane = selectedItem != nil ? .item(selectedItem!) : nil }
             )
+            .environmentObject(viewModel)
         case .edit(let item):
             EditItemView(
                 editableItem: item,

--- a/RoomRoster/Views/SalesDetailsView.swift
+++ b/RoomRoster/Views/SalesDetailsView.swift
@@ -103,15 +103,17 @@ struct SalesDetailsView: View {
 #endif
         }
         .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                Button(l10n.editButton) {
 #if os(macOS)
-                    openEdit?(sale)
-#else
-                    isEditing = true
-#endif
+            if let openEdit {
+                ToolbarItem(placement: .primaryAction) {
+                    Button(l10n.editButton) { openEdit(sale) }
                 }
             }
+#else
+            ToolbarItem(placement: .primaryAction) {
+                Button(l10n.editButton) { isEditing = true }
+            }
+#endif
         }
         .sheet(item: $shareURL) { url in
             ShareSheet(activityItems: [url])

--- a/RoomRoster/Views/SalesDetailsView.swift
+++ b/RoomRoster/Views/SalesDetailsView.swift
@@ -19,8 +19,10 @@ struct SalesDetailsView: View {
     var body: some View {
 #if os(macOS)
         NavigationStack { content }
+            .navigationDestination(isPresented: $isEditing) { editSaleView }
 #else
         content
+            .navigationDestination(isPresented: $isEditing) { editSaleView }
 #endif
     }
 
@@ -92,13 +94,6 @@ struct SalesDetailsView: View {
                 Button(l10n.editButton) { isEditing = true }
             }
         }
-        .background(
-            NavigationLink(
-                destination: editSaleView,
-                isActive: $isEditing
-            ) { EmptyView() }
-            .hidden()
-        )
         .sheet(item: $shareURL) { url in
             ShareSheet(activityItems: [url])
         }

--- a/RoomRoster/Views/SalesDetailsView.swift
+++ b/RoomRoster/Views/SalesDetailsView.swift
@@ -5,23 +5,34 @@ private typealias l10n = Strings.saleDetails
 struct SalesDetailsView: View {
     @State var sale: Sale
     let itemName: String
+#if os(macOS)
+    var openEdit: ((Sale) -> Void)? = nil
+#endif
 
-    init(sale: Sale, itemName: String) {
+    init(sale: Sale, itemName: String
+#if os(macOS)
+         , openEdit: ((Sale) -> Void)? = nil
+#endif
+    ) {
         _sale = State(initialValue: sale)
         self.itemName = itemName
+#if os(macOS)
+        self.openEdit = openEdit
+#endif
     }
     @State private var shareURL: URL?
     @State private var errorMessage: String?
+#if !os(macOS)
     @State private var editSuccess: String?
     @State private var isEditing = false
+#endif
     private let downloader = FileDownloadService()
 
     var body: some View {
 #if os(macOS)
-        NavigationStack { content }
-            .navigationDestination(isPresented: $isEditing) { editSaleView }
-#else
         content
+#else
+        NavigationStack { content }
             .navigationDestination(isPresented: $isEditing) { editSaleView }
 #endif
     }
@@ -84,14 +95,22 @@ struct SalesDetailsView: View {
                 VStack { Spacer(); ErrorBanner(message: errorMessage) }
                     .allowsHitTesting(false)
             }
+#if !os(macOS)
             if let message = editSuccess {
                 VStack { Spacer(); SuccessBanner(message: message) }
                     .allowsHitTesting(false)
             }
+#endif
         }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
-                Button(l10n.editButton) { isEditing = true }
+                Button(l10n.editButton) {
+#if os(macOS)
+                    openEdit?(sale)
+#else
+                    isEditing = true
+#endif
+                }
             }
         }
         .sheet(item: $shareURL) { url in
@@ -111,11 +130,13 @@ struct SalesDetailsView: View {
     private var editSaleView: some View {
         EditSaleView(viewModel: EditSaleViewModel(sale: sale)) { updated in
             sale = updated
+#if !os(macOS)
             editSuccess = Strings.saleDetails.editSuccess
             HapticManager.shared.success()
             DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
                 withAnimation { editSuccess = nil }
             }
+#endif
         }
     }
 }

--- a/RoomRoster/Views/SalesDetailsView.swift
+++ b/RoomRoster/Views/SalesDetailsView.swift
@@ -13,6 +13,7 @@ struct SalesDetailsView: View {
     @State private var shareURL: URL?
     @State private var errorMessage: String?
     @State private var editSuccess: String?
+    @State private var isEditing = false
     private let downloader = FileDownloadService()
 
     var body: some View {
@@ -88,9 +89,16 @@ struct SalesDetailsView: View {
         }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
-                NavigationLink(l10n.editButton) { editSaleView }
+                Button(l10n.editButton) { isEditing = true }
             }
         }
+        .background(
+            NavigationLink(
+                destination: editSaleView,
+                isActive: $isEditing
+            ) { EmptyView() }
+            .hidden()
+        )
         .sheet(item: $shareURL) { url in
             ShareSheet(activityItems: [url])
         }

--- a/RoomRoster/Views/SalesDetailsView.swift
+++ b/RoomRoster/Views/SalesDetailsView.swift
@@ -7,19 +7,18 @@ struct SalesDetailsView: View {
     let itemName: String
 #if os(macOS)
     var openEdit: ((Sale) -> Void)? = nil
-#endif
 
-    init(sale: Sale, itemName: String
-#if os(macOS)
-         , openEdit: ((Sale) -> Void)? = nil
-#endif
-    ) {
+    init(sale: Sale, itemName: String, openEdit: ((Sale) -> Void)? = nil) {
         _sale = State(initialValue: sale)
         self.itemName = itemName
-#if os(macOS)
         self.openEdit = openEdit
-#endif
     }
+#else
+    init(sale: Sale, itemName: String) {
+        _sale = State(initialValue: sale)
+        self.itemName = itemName
+    }
+#endif
     @State private var shareURL: URL?
     @State private var errorMessage: String?
 #if !os(macOS)


### PR DESCRIPTION
## Summary
- fix macOS SalesDetailsView edit button to open EditSaleView
- ensure CreateItemView loads room list after signing in on macOS

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688e4ec022e0832cb6065ddb33ce212a