### PR TITLE
Fix duplicated item creation and room form reset

### DIFF
--- a/RoomRoster/Views/InventoryView.swift
+++ b/RoomRoster/Views/InventoryView.swift
@@ -26,8 +26,6 @@ struct InventoryView: View {
         case saleDetails(Sale, Item)
     }
     @State private var pane: Pane?
-#else
-    @State private var showCreateItemView = false
 #endif
     @State private var expandedRooms: Set<Room> = []
     @State private var searchText: String = ""
@@ -72,7 +70,12 @@ struct InventoryView: View {
         }
     }
 #if !os(macOS)
-        .platformPopup(isPresented: $showCreateItemView) {
+        .platformPopup(
+            isPresented: Binding(
+                get: { createItemViewModel != nil },
+                set: { if !$0 { createItemViewModel = nil } }
+            )
+        ) {
             if let createItemViewModel {
                 CreateItemView(viewModel: createItemViewModel)
                     .environmentObject(viewModel)
@@ -317,7 +320,6 @@ struct InventoryView: View {
                             }
                         }
                     )
-                    showCreateItemView = true
                 }) {
                     Image(systemName: "plus")
                         .font(.system(size: 24))


### PR DESCRIPTION
## Summary
- prevent duplicate create item submissions by removing extra API call
- preserve CreateItemView state so adding a room doesn't reset the form

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme RoomRoster -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68925bb88ccc832ca0be944e02d51e9e