### PR TITLE
Add Codable support for PropertyTagRange

### DIFF
--- a/RoomRosterTests/PropertyTagRangeTests.swift
+++ b/RoomRosterTests/PropertyTagRangeTests.swift
@@ -21,4 +21,17 @@ final class PropertyTagRangeTests: XCTestCase {
     func testInvalidRangeReturnsNil() {
         XCTAssertNil(PropertyTagRange(from: "A0003-A0001"))
     }
+
+    func testDifferentInitialLettersNotAllowed() {
+        XCTAssertNil(PropertyTagRange(from: "A1000-B1000"))
+    }
+
+    func testCodableRoundTrip() throws {
+        let original = "A0001-A0003,B0001"
+        let range = PropertyTagRange(from: original)!
+        let data = try JSONEncoder().encode(range)
+        let decoded = try JSONDecoder().decode(PropertyTagRange.self, from: data)
+        XCTAssertEqual(range, decoded)
+        XCTAssertEqual(String(data: data, encoding: .utf8), "\"A0001-A0003,B0001\"")
+    }
 }


### PR DESCRIPTION
## Summary
- support encoding/decoding PropertyTagRange to a string form for backend communication
- reject tag ranges spanning different initial letters
- test PropertyTagRange decoding/encoding and invalid cross-letter ranges

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project RoomRoster.xcodeproj -scheme RoomRoster -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_689286003048832caf9c0f67e94da92b