### PR TITLE
Populate audit fields on item creation

### DIFF
--- a/RoomRoster/ViewModels/CreateItemViewModel.swift
+++ b/RoomRoster/ViewModels/CreateItemViewModel.swift
@@ -210,6 +210,8 @@ final class CreateItemViewModel: ObservableObject {
         validateTag()
         guard tagError == nil else { return }
         do {
+            newItem.updatedBy = AuthenticationManager.shared.userName ?? ""
+            newItem.lastUpdated = Date()
             try await inventoryService.createItem(newItem)
             onSave?(newItem)
         } catch {


### PR DESCRIPTION
## Summary
- set `updatedBy` and `lastUpdated` when saving a new item

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68952a20d4e0832cae0af812a49dc76c