### PR TITLE
Add barcode scanner for item forms

### DIFF
--- a/RoomRoster.xcodeproj/project.pbxproj
+++ b/RoomRoster.xcodeproj/project.pbxproj
@@ -99,8 +99,9 @@
 		C616CDE1A2B34C5D67890ABE /* SalesDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C616CDE1A2B34C5D67890ABD /* SalesDetailsView.swift */; };
 		CE2487F2AA23494BBE56993D /* ReportsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12FE82B0693248D49E8D77BB /* ReportsViewModel.swift */; };
 		DE7D257232324BDDB96C6F37 /* RoomServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614508236AFA4269887FF35A /* RoomServiceTests.swift */; };
-		E0B282C5B6FF4AADB74F1235 /* DocumentPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B282C5B6FF4AADB74F1234 /* DocumentPickerView.swift */; };
-		E9FBF450607D494DA1894333 /* MockNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF137618CD644A1997B55ED6 /* MockNetworkService.swift */; };
+                E0B282C5B6FF4AADB74F1235 /* DocumentPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B282C5B6FF4AADB74F1234 /* DocumentPickerView.swift */; };
+                AF92508CC3AD4558844194AA /* BarcodeScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2987006832490F89CFB17C /* BarcodeScannerView.swift */; };
+                E9FBF450607D494DA1894333 /* MockNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF137618CD644A1997B55ED6 /* MockNetworkService.swift */; };
 		EC28A959CE63441E9F3C1048 /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EC0F7257914A11A7589F29 /* ShareSheet.swift */; };
                 FDB33D97700C2EF04190FA52 /* GmailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C01D35FCE10EB02BEFD65D29 /* GmailService.swift */; };
                 FB42C5677D8D477793E2A66E /* PlatformImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA014E93EE2475992EB91B0 /* PlatformImage.swift */; };
@@ -209,9 +210,10 @@
 		C616CDE1A2B34C5D67890ABD /* SalesDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesDetailsView.swift; sourceTree = "<group>"; };
 		C66A533C9D0B40A885DA2172 /* Condition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Condition.swift; sourceTree = "<group>"; };
 		D635C54A7B58948D1F8036B4 /* SpreadsheetManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpreadsheetManagerTests.swift; sourceTree = "<group>"; };
-		E0B282C5B6FF4AADB74F1234 /* DocumentPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentPickerView.swift; sourceTree = "<group>"; };
-		E32FE1D99B3B44E6A6801234 /* SalesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesViewModel.swift; sourceTree = "<group>"; };
-		E71B5019D5A040FCBB81807B /* ItemValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemValidatorTests.swift; sourceTree = "<group>"; };
+            E0B282C5B6FF4AADB74F1234 /* DocumentPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentPickerView.swift; sourceTree = "<group>"; };
+            DA2987006832490F89CFB17C /* BarcodeScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeScannerView.swift; sourceTree = "<group>"; };
+            E32FE1D99B3B44E6A6801234 /* SalesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesViewModel.swift; sourceTree = "<group>"; };
+            E71B5019D5A040FCBB81807B /* ItemValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemValidatorTests.swift; sourceTree = "<group>"; };
                 ABCDEF01234567890123456A /* PropertyTagRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyTagRangeTests.swift; sourceTree = "<group>"; };
 		F1DB1AD2C44D425AB9A59153 /* SellItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellItemViewModel.swift; sourceTree = "<group>"; };
                 F2ACBFBB75EA4E3C9514A9AB /* DepreciationCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepreciationCalculatorTests.swift; sourceTree = "<group>"; };
@@ -263,9 +265,10 @@
 				B66016AE2DA9CEDC0012FDD0 /* CreateItemView.swift */,
 				767E82D42D8F356500B48011 /* EditItemView.swift */,
 				B646DBB22E342D270040A437 /* EditSaleView.swift */,
-				B612436B2DB03BA000B9098B /* ImagePickerView.swift */,
-				E0B282C5B6FF4AADB74F1234 /* DocumentPickerView.swift */,
-		767B05912D4C5DC000566C25 /* InventoryView.swift */,
+                                B612436B2DB03BA000B9098B /* ImagePickerView.swift */,
+                                E0B282C5B6FF4AADB74F1234 /* DocumentPickerView.swift */,
+                                DA2987006832490F89CFB17C /* BarcodeScannerView.swift */,
+                                767B05912D4C5DC000566C25 /* InventoryView.swift */,
 				767B05C02D4C666F00566C25 /* ItemDetailsView.swift */,
 				B65F71242DE6491700310D40 /* MainMenuView.swift */,
 				B65F71262DE6493600310D40 /* ReportsView.swift */,
@@ -629,10 +632,11 @@
 				B615ED1E2DE226E1009BE623 /* PropertyTag.swift in Sources */,
 				767B05902D4C5DC000566C25 /* RoomRosterApp.swift in Sources */,
 				B65F71292DE6494A00310D40 /* SheetsView.swift in Sources */,
-				B612436C2DB03BA000B9098B /* ImagePickerView.swift in Sources */,
-				E0B282C5B6FF4AADB74F1235 /* DocumentPickerView.swift in Sources */,
-				A1E0B1C14AD24FA3B4C56D7F /* ReceiptImageView.swift in Sources */,
-				B615ED202DE2BB15009BE623 /* Room.swift in Sources */,
+                                B612436C2DB03BA000B9098B /* ImagePickerView.swift in Sources */,
+                                E0B282C5B6FF4AADB74F1235 /* DocumentPickerView.swift in Sources */,
+                                AF92508CC3AD4558844194AA /* BarcodeScannerView.swift in Sources */,
+                                A1E0B1C14AD24FA3B4C56D7F /* ReceiptImageView.swift in Sources */,
+                                B615ED202DE2BB15009BE623 /* Room.swift in Sources */,
 				8030ADBBCBB442E3B8D6D5FB /* Condition.swift in Sources */,
 				9E010CFAAB177DFBCE24F75D /* PurchaseReceiptService.swift in Sources */,
 				B0230BC284FF666FFF0227E5 /* ReceiptFileType.swift in Sources */,

--- a/RoomRoster/Views/BarcodeScannerView.swift
+++ b/RoomRoster/Views/BarcodeScannerView.swift
@@ -21,14 +21,15 @@ struct BarcodeScannerView: UIViewControllerRepresentable {
     final class Coordinator: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCaptureVideoDataOutputSampleBufferDelegate {
         let onScan: (String) -> Void
         private var didScan = false
-        private var legacyScanRequested = false
+        private var legacyBoostFrames = 0
+        private var frameCounter = 0
 
         init(onScan: @escaping (String) -> Void) {
             self.onScan = onScan
         }
 
-        func requestLegacyScan() {
-            legacyScanRequested = true
+        func boostLegacyScan() {
+            legacyBoostFrames = 60
         }
 
         func metadataOutput(
@@ -50,11 +51,13 @@ struct BarcodeScannerView: UIViewControllerRepresentable {
             didOutput sampleBuffer: CMSampleBuffer,
             from connection: AVCaptureConnection
         ) {
-            guard !didScan, legacyScanRequested,
+            guard !didScan,
                   let buffer = CMSampleBufferGetImageBuffer(sampleBuffer)
             else { return }
 
-            legacyScanRequested = false
+            frameCounter += 1
+            if legacyBoostFrames <= 0 && frameCounter % 15 != 0 { return }
+            if legacyBoostFrames > 0 { legacyBoostFrames -= 1 }
 
             let request = VNRecognizeTextRequest { [weak self] request, error in
                 guard
@@ -66,16 +69,24 @@ struct BarcodeScannerView: UIViewControllerRepresentable {
                 for observation in results {
                     guard let candidate = observation.topCandidates(1).first else { continue }
                     let text = candidate.string.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if text.range(of: "^A\\d{4}$", options: .regularExpression) != nil {
+                    if candidate.confidence > 0.8,
+                       text.range(of: "^A\\d{4}$", options: .regularExpression) != nil {
                         self.didScan = true
                         self.onScan(text)
                         break
                     }
                 }
             }
-            request.recognitionLevel = .fast
+            request.recognitionLevel = legacyBoostFrames > 0 ? .accurate : .fast
+            request.minimumTextHeight = 0.05
+            request.recognitionLanguages = ["en-US"]
+            request.usesLanguageCorrection = false
 
-            let handler = VNImageRequestHandler(cvPixelBuffer: buffer, orientation: .up, options: [:])
+            let handler = VNImageRequestHandler(
+                cvPixelBuffer: buffer,
+                orientation: CGImagePropertyOrientation(UIDevice.current.orientation),
+                options: [:]
+            )
             try? handler.perform([request])
         }
     }
@@ -83,6 +94,7 @@ struct BarcodeScannerView: UIViewControllerRepresentable {
     final class ScannerViewController: UIViewController {
         var coordinator: Coordinator?
         private let session = AVCaptureSession()
+        private var preview: AVCaptureVideoPreviewLayer?
 
         override func viewDidLoad() {
             super.viewDidLoad()
@@ -108,6 +120,14 @@ struct BarcodeScannerView: UIViewControllerRepresentable {
             preview.videoGravity = .resizeAspectFill
             preview.frame = view.layer.bounds
             view.layer.addSublayer(preview)
+            self.preview = preview
+
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(orientationChanged),
+                name: UIDevice.orientationDidChangeNotification,
+                object: nil
+            )
 
             let doubleTap = UITapGestureRecognizer(target: self, action: #selector(handleDoubleTap))
             doubleTap.numberOfTapsRequired = 2
@@ -117,6 +137,7 @@ struct BarcodeScannerView: UIViewControllerRepresentable {
         override func viewDidAppear(_ animated: Bool) {
             super.viewDidAppear(animated)
             session.startRunning()
+            updatePreviewOrientation()
         }
 
         override func viewWillDisappear(_ animated: Bool) {
@@ -124,8 +145,54 @@ struct BarcodeScannerView: UIViewControllerRepresentable {
             session.stopRunning()
         }
 
+        override func viewDidLayoutSubviews() {
+            super.viewDidLayoutSubviews()
+            preview?.frame = view.bounds
+            updatePreviewOrientation()
+        }
+
+        deinit {
+            NotificationCenter.default.removeObserver(self)
+        }
+
         @objc private func handleDoubleTap() {
-            coordinator?.requestLegacyScan()
+            coordinator?.boostLegacyScan()
+        }
+
+        @objc private func orientationChanged() {
+            updatePreviewOrientation()
+        }
+
+        private func updatePreviewOrientation() {
+            guard let connection = preview?.connection,
+                  connection.isVideoOrientationSupported,
+                  let videoOrientation = AVCaptureVideoOrientation(deviceOrientation: UIDevice.current.orientation)
+            else { return }
+            connection.videoOrientation = videoOrientation
+        }
+    }
+}
+
+private extension AVCaptureVideoOrientation {
+    init?(deviceOrientation: UIDeviceOrientation) {
+        switch deviceOrientation {
+        case .portrait: self = .portrait
+        case .portraitUpsideDown: self = .portraitUpsideDown
+        case .landscapeLeft: self = .landscapeRight
+        case .landscapeRight: self = .landscapeLeft
+        default: return nil
+        }
+    }
+}
+
+private extension CGImagePropertyOrientation {
+    init(_ deviceOrientation: UIDeviceOrientation) {
+        switch deviceOrientation {
+        case .portrait: self = .right
+        case .portraitUpsideDown: self = .left
+        case .landscapeLeft: self = .up
+        case .landscapeRight: self = .down
+        default: self = .right
         }
     }
 }

--- a/RoomRoster/Views/BarcodeScannerView.swift
+++ b/RoomRoster/Views/BarcodeScannerView.swift
@@ -1,0 +1,88 @@
+#if canImport(AVFoundation) && !targetEnvironment(macCatalyst)
+import SwiftUI
+import AVFoundation
+
+struct BarcodeScannerView: UIViewControllerRepresentable {
+    var onScan: (String) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onScan: onScan)
+    }
+
+    func makeUIViewController(context: Context) -> ScannerViewController {
+        let controller = ScannerViewController()
+        controller.coordinator = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: ScannerViewController, context: Context) {}
+
+    final class Coordinator: NSObject, AVCaptureMetadataOutputObjectsDelegate {
+        let onScan: (String) -> Void
+
+        init(onScan: @escaping (String) -> Void) {
+            self.onScan = onScan
+        }
+
+        func metadataOutput(
+            _ output: AVCaptureMetadataOutput,
+            didOutput metadataObjects: [AVMetadataObject],
+            from connection: AVCaptureConnection
+        ) {
+            guard
+                let object = metadataObjects.first as? AVMetadataMachineReadableCodeObject,
+                let value = object.stringValue
+            else { return }
+            onScan(value)
+        }
+    }
+
+    final class ScannerViewController: UIViewController {
+        var coordinator: Coordinator?
+        private let session = AVCaptureSession()
+
+        override func viewDidLoad() {
+            super.viewDidLoad()
+            guard
+                let device = AVCaptureDevice.default(for: .video),
+                let input = try? AVCaptureDeviceInput(device: device)
+            else { return }
+            session.addInput(input)
+
+            let output = AVCaptureMetadataOutput()
+            session.addOutput(output)
+            output.setMetadataObjectsDelegate(coordinator, queue: .main)
+            output.metadataObjectTypes = [
+                .ean8, .ean13, .pdf417, .code128, .code39, .code39Mod43,
+                .code93, .upce, .aztec, .qr
+            ]
+
+            let preview = AVCaptureVideoPreviewLayer(session: session)
+            preview.videoGravity = .resizeAspectFill
+            preview.frame = view.layer.bounds
+            view.layer.addSublayer(preview)
+        }
+
+        override func viewDidAppear(_ animated: Bool) {
+            super.viewDidAppear(animated)
+            session.startRunning()
+        }
+
+        override func viewWillDisappear(_ animated: Bool) {
+            super.viewWillDisappear(animated)
+            session.stopRunning()
+        }
+    }
+}
+#else
+import SwiftUI
+
+struct BarcodeScannerView: View {
+    var onScan: (String) -> Void
+
+    var body: some View {
+        Text("Barcode scanning not available")
+            .padding()
+    }
+}
+#endif

--- a/RoomRoster/Views/CreateItemView.swift
+++ b/RoomRoster/Views/CreateItemView.swift
@@ -17,6 +17,7 @@ struct CreateItemView: View {
 
     @FocusState private var tagFieldFocused: Bool
     @State private var successMessage: String?
+    @State private var showScanner = false
 #if os(macOS)
     private let fieldWidth: CGFloat = 240.0
 #endif
@@ -147,7 +148,11 @@ struct CreateItemView: View {
                     TextField(l10n.basicInfo.enter.tag, text: $viewModel.propertyTagInput)
                         .focused($tagFieldFocused)
                         .frame(width: fieldWidth)
-                        .padding(.trailing, 4)
+                        .padding(.trailing, 28)
+                        .overlay(alignment: .trailing) {
+                            scanButton
+                                .padding(.trailing, 4)
+                        }
                         .onChange(of: tagFieldFocused) { focused in
                             if !focused {
                                 withAnimation { viewModel.validateTag() }
@@ -182,7 +187,10 @@ struct CreateItemView: View {
                     TextField(l10n.basicInfo.enter.tag, text: $viewModel.propertyTagInput)
                         .focused($tagFieldFocused)
                         .multilineTextAlignment(.trailing)
-                        .padding(.trailing)
+                        .padding(.trailing, 28)
+                        .overlay(alignment: .trailing) {
+                            scanButton
+                        }
                         .onChange(of: tagFieldFocused) { focused in
                             if !focused {
                                 withAnimation { viewModel.validateTag() }
@@ -376,6 +384,28 @@ struct CreateItemView: View {
         .onChange(of: inventory.rooms) { newRooms in
             viewModel.rooms = newRooms
         }
+        .sheet(isPresented: $showScanner) {
+            BarcodeScannerView { code in
+                viewModel.propertyTagInput = code
+                viewModel.validateTag()
+                showScanner = false
+            }
+        }
+    }
+
+    private var scanButton: some View {
+        #if targetEnvironment(macCatalyst)
+        Button(action: {}) {
+            Image(systemName: "barcode.viewfinder")
+        }
+        .disabled(true)
+        #else
+        Button {
+            showScanner = true
+        } label: {
+            Image(systemName: "barcode.viewfinder")
+        }
+        #endif
     }
 
 #if os(macOS)

--- a/RoomRoster/Views/EditItemView.swift
+++ b/RoomRoster/Views/EditItemView.swift
@@ -37,6 +37,7 @@ struct EditItemView: View {
     @State private var dateAddedDate: Date = Date()
     @State private var propertyTagInput: String = ""
     @State private var tagError: String? = nil
+    @State private var showScanner = false
     @State private var showingAddRoomPrompt = false
     @State private var newRoomName = ""
     @FocusState private var tagFieldFocused: Bool
@@ -150,7 +151,11 @@ struct EditItemView: View {
                         TextField(l10n.basicInfo.enter.tag, text: $propertyTagInput)
                             .focused($tagFieldFocused)
                             .frame(width: fieldWidth)
-                            .padding(.trailing, 4)
+                            .padding(.trailing, 28)
+                            .overlay(alignment: .trailing) {
+                                scanButton
+                                    .padding(.trailing, 4)
+                            }
                             .onChange(of: tagFieldFocused) { focused in
                                 if !focused {
                                     withAnimation { validateTag() }
@@ -202,7 +207,11 @@ struct EditItemView: View {
                         TextField(l10n.basicInfo.enter.tag, text: $propertyTagInput)
                             .focused($tagFieldFocused)
                             .textFieldStyle(.roundedBorder)
-                            .padding(.trailing)
+                            .padding(.trailing, 28)
+                            .overlay(alignment: .trailing) {
+                                scanButton
+                                    .padding(.trailing, 8)
+                            }
                             .onChange(of: tagFieldFocused) { focused in
                                 if !focused {
                                     withAnimation {
@@ -398,6 +407,28 @@ struct EditItemView: View {
         .task {
             await viewModel.loadRooms()
         }
+        .sheet(isPresented: $showScanner) {
+            BarcodeScannerView { code in
+                propertyTagInput = code
+                validateTag()
+                showScanner = false
+            }
+        }
+    }
+
+    private var scanButton: some View {
+        #if targetEnvironment(macCatalyst)
+        Button(action: {}) {
+            Image(systemName: "barcode.viewfinder")
+        }
+        .disabled(true)
+        #else
+        Button {
+            showScanner = true
+        } label: {
+            Image(systemName: "barcode.viewfinder")
+        }
+        #endif
     }
 
 #if os(macOS)


### PR DESCRIPTION
## Summary
- add `BarcodeScannerView` using AVFoundation with fallback when scanning unavailable
- integrate scanner buttons into Create and Edit item forms and validate scanned tags
- link new view in Xcode project

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68952b06f180832c877ddbfa83ae1d59