### PR TITLE
Add search and filter controls to sales list

### DIFF
--- a/RoomRoster/ViewModels/SalesViewModel.swift
+++ b/RoomRoster/ViewModels/SalesViewModel.swift
@@ -37,4 +37,29 @@ final class SalesViewModel: ObservableObject {
     func itemName(for sale: Sale) -> String {
         itemsById[sale.itemId]?.name ?? Strings.general.loading
     }
+
+    func filteredSales(
+        query: String,
+        startDate: Date?,
+        endDate: Date?,
+        minPrice: Double?,
+        maxPrice: Double?
+    ) -> [Sale] {
+        let q = query.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        return sales.filter { sale in
+            if !q.isEmpty {
+                let name = itemName(for: sale).lowercased()
+                if !name.contains(q) { return false }
+            }
+            if let start = startDate, sale.date < start { return false }
+            if let end = endDate, sale.date > end { return false }
+            if let min = minPrice {
+                guard let price = sale.price, price >= min else { return false }
+            }
+            if let max = maxPrice {
+                guard let price = sale.price, price <= max else { return false }
+            }
+            return true
+        }
+    }
 }

--- a/RoomRoster/ViewModels/SalesViewModel.swift
+++ b/RoomRoster/ViewModels/SalesViewModel.swift
@@ -40,8 +40,7 @@ final class SalesViewModel: ObservableObject {
 
     func filteredSales(
         query: String,
-        startDate: Date?,
-        endDate: Date?,
+        dateRange: ClosedRange<Date>?,
         minPrice: Double?,
         maxPrice: Double?
     ) -> [Sale] {
@@ -51,8 +50,9 @@ final class SalesViewModel: ObservableObject {
                 let name = itemName(for: sale).lowercased()
                 if !name.contains(q) { return false }
             }
-            if let start = startDate, sale.date < start { return false }
-            if let end = endDate, sale.date > end { return false }
+            if let range = dateRange {
+                if sale.date < range.lowerBound || sale.date > range.upperBound { return false }
+            }
             if let min = minPrice {
                 guard let price = sale.price, price >= min else { return false }
             }

--- a/RoomRoster/ViewModels/SalesViewModel.swift
+++ b/RoomRoster/ViewModels/SalesViewModel.swift
@@ -40,7 +40,7 @@ final class SalesViewModel: ObservableObject {
 
     func filteredSales(
         query: String,
-        dateRange: DateInterval?,
+        dateRange: ClosedRange<Date>?,
         minPrice: Double?,
         maxPrice: Double?
     ) -> [Sale] {

--- a/RoomRoster/ViewModels/SalesViewModel.swift
+++ b/RoomRoster/ViewModels/SalesViewModel.swift
@@ -40,7 +40,7 @@ final class SalesViewModel: ObservableObject {
 
     func filteredSales(
         query: String,
-        dateRange: ClosedRange<Date>?,
+        dateRange: DateInterval?,
         minPrice: Double?,
         maxPrice: Double?
     ) -> [Sale] {
@@ -51,7 +51,7 @@ final class SalesViewModel: ObservableObject {
                 if !name.contains(q) { return false }
             }
             if let range = dateRange {
-                if sale.date < range.lowerBound || sale.date > range.upperBound { return false }
+                if !range.contains(sale.date) { return false }
             }
             if let min = minPrice {
                 guard let price = sale.price, price >= min else { return false }

--- a/RoomRoster/Views/SalesView.swift
+++ b/RoomRoster/Views/SalesView.swift
@@ -17,7 +17,7 @@ struct SalesView: View {
     @State private var successMessage: String?
 
     @State private var searchText: String = ""
-    @State private var dateRange: ClosedRange<Date>?
+    @State private var dateRange: DateInterval?
     @State private var minPrice: Double?
     @State private var maxPrice: Double?
 
@@ -252,11 +252,10 @@ struct SalesView: View {
             }
             DatePicker(
                 "Date Range",
-                selection: Binding<ClosedRange<Date>>(
-                    get: { dateRange ?? Date()...Date() },
+                selection: Binding<DateInterval>(
+                    get: { dateRange ?? DateInterval(start: Date(), end: Date()) },
                     set: { dateRange = $0 }
                 ),
-                in: Date.distantPast...Date.distantFuture,
                 displayedComponents: .date
             )
             HStack {

--- a/RoomRoster/Views/SalesView.swift
+++ b/RoomRoster/Views/SalesView.swift
@@ -17,8 +17,7 @@ struct SalesView: View {
     @State private var successMessage: String?
 
     @State private var searchText: String = ""
-    @State private var startDate: Date?
-    @State private var endDate: Date?
+    @State private var dateRange: ClosedRange<Date>?
     @State private var minPrice: Double?
     @State private var maxPrice: Double?
 
@@ -132,8 +131,7 @@ struct SalesView: View {
         }
 #if os(macOS)
         .onChange(of: searchText) { _ in updateSelection() }
-        .onChange(of: startDate) { _ in updateSelection() }
-        .onChange(of: endDate) { _ in updateSelection() }
+        .onChange(of: dateRange) { _ in updateSelection() }
         .onChange(of: minPrice) { _ in updateSelection() }
         .onChange(of: maxPrice) { _ in updateSelection() }
 #endif
@@ -247,20 +245,16 @@ struct SalesView: View {
     @ViewBuilder
     private var filterHeader: some View {
         VStack {
-            TextField("Search", text: $searchText)
-                .textFieldStyle(.roundedBorder)
             HStack {
-                DatePicker(
-                    "From",
-                    selection: Binding(get: { startDate ?? Date() }, set: { startDate = $0 }),
-                    displayedComponents: .date
-                )
-                DatePicker(
-                    "To",
-                    selection: Binding(get: { endDate ?? Date() }, set: { endDate = $0 }),
-                    displayedComponents: .date
-                )
+                TextField("Search", text: $searchText)
+                    .textFieldStyle(.roundedBorder)
+                Button("Clear") { clearFilters() }
             }
+            DatePicker(
+                "Date Range",
+                selection: Binding(get: { dateRange ?? Date()...Date() }, set: { dateRange = $0 }),
+                displayedComponents: .date
+            )
             HStack {
                 TextField(
                     "Min Price",
@@ -279,8 +273,7 @@ struct SalesView: View {
     private var filteredSales: [Sale] {
         viewModel.filteredSales(
             query: searchText,
-            startDate: startDate,
-            endDate: endDate,
+            dateRange: dateRange,
             minPrice: minPrice,
             maxPrice: maxPrice
         )
@@ -296,4 +289,11 @@ struct SalesView: View {
         }
     }
 #endif
+
+    private func clearFilters() {
+        searchText = ""
+        dateRange = nil
+        minPrice = nil
+        maxPrice = nil
+    }
 }

--- a/RoomRoster/Views/SalesView.swift
+++ b/RoomRoster/Views/SalesView.swift
@@ -32,6 +32,15 @@ struct SalesView: View {
     }
 #endif
 
+    private static let allDates: ClosedRange<Date> = Date.distantPast...Date.distantFuture
+
+    private var dateRangeBinding: Binding<ClosedRange<Date>> {
+        Binding(
+            get: { dateRange ?? Self.allDates },
+            set: { dateRange = $0 }
+        )
+    }
+
     var body: some View {
         ZStack(alignment: .bottom) {
         Group {
@@ -252,13 +261,10 @@ struct SalesView: View {
             }
             DatePicker(
                 "Date Range",
-                selection: Binding<ClosedRange<Date>>(
-                    get: { dateRange ?? Date.distantPast...Date.distantFuture },
-                    set: { dateRange = $0 }
-                ),
-                in: Date.distantPast...Date.distantFuture,
+                selection: dateRangeBinding,
                 displayedComponents: .date
             )
+            .datePickerStyle(.graphical)
             HStack {
                 TextField(
                     "Min Price",

--- a/RoomRoster/Views/SalesView.swift
+++ b/RoomRoster/Views/SalesView.swift
@@ -252,10 +252,11 @@ struct SalesView: View {
             }
             DatePicker(
                 "Date Range",
-                selection: Binding(
-                    get: { dateRange ?? Date()...Date() },
+                selection: Binding<ClosedRange<Date>>(
+                    get: { dateRange ?? Date.distantPast...Date.distantFuture },
                     set: { dateRange = $0 }
                 ),
+                in: Date.distantPast...Date.distantFuture,
                 displayedComponents: .date
             )
             HStack {

--- a/RoomRoster/Views/SalesView.swift
+++ b/RoomRoster/Views/SalesView.swift
@@ -252,7 +252,11 @@ struct SalesView: View {
             }
             DatePicker(
                 "Date Range",
-                selection: Binding(get: { dateRange ?? Date()...Date() }, set: { dateRange = $0 }),
+                selection: Binding<ClosedRange<Date>>(
+                    get: { dateRange ?? Date()...Date() },
+                    set: { dateRange = $0 }
+                ),
+                in: Date.distantPast...Date.distantFuture,
                 displayedComponents: .date
             )
             HStack {

--- a/RoomRoster/Views/SalesView.swift
+++ b/RoomRoster/Views/SalesView.swift
@@ -17,7 +17,7 @@ struct SalesView: View {
     @State private var successMessage: String?
 
     @State private var searchText: String = ""
-    @State private var dateRange: DateInterval?
+    @State private var dateRange: ClosedRange<Date>?
     @State private var minPrice: Double?
     @State private var maxPrice: Double?
 
@@ -252,8 +252,8 @@ struct SalesView: View {
             }
             DatePicker(
                 "Date Range",
-                selection: Binding<DateInterval>(
-                    get: { dateRange ?? DateInterval(start: Date(), end: Date()) },
+                selection: Binding(
+                    get: { dateRange ?? Date()...Date() },
                     set: { dateRange = $0 }
                 ),
                 displayedComponents: .date


### PR DESCRIPTION
## Summary
- add search, date, and price filters to sales list header
- filter sales in `SalesViewModel` based on query and filters
- keep navigation selection in sync with filtered results

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68952b984b00832c86363c7ca6b19383