### PR TITLE
Fix inventory navigation and sync quantity with tags

### DIFF
--- a/RoomRoster/Utilities/ItemValidator.swift
+++ b/RoomRoster/Utilities/ItemValidator.swift
@@ -33,14 +33,15 @@ struct ItemValidator {
     ///
     /// - Parameters:
     ///   - input: The raw tag string entered by the user.
-    ///   - quantity: Expected number of items. Must match the number of parsed tags.
+    ///   - quantity: Optional expected number of items. When provided, the number of
+    ///               parsed tags must match this value.
     ///   - currentItemID: If editing an existing item, its identifier so duplicates are ignored.
     ///   - allItems: Existing items used to check for duplicate tags.
     /// - Throws: ``ItemValidationError`` if the input is invalid or contains duplicates.
     /// - Returns: Parsed property tags.
     static func validateTags(
         _ input: String,
-        quantity: Int,
+        quantity: Int? = nil,
         currentItemID: String?,
         allItems: [Item]
     ) throws -> [PropertyTag] {
@@ -48,7 +49,7 @@ struct ItemValidator {
             throw ItemValidationError.invalidTagFormat
         }
 
-        if range.tags.count != quantity {
+        if let quantity, range.tags.count != quantity {
             throw ItemValidationError.quantityMismatch
         }
 

--- a/RoomRoster/ViewModels/CreateItemViewModel.swift
+++ b/RoomRoster/ViewModels/CreateItemViewModel.swift
@@ -150,10 +150,10 @@ final class CreateItemViewModel: ObservableObject {
         do {
             let tags = try ItemValidator.validateTags(
                 propertyTagInput,
-                quantity: newItem.quantity,
                 currentItemID: nil,
                 allItems: itemsProvider()
             )
+            newItem.quantity = tags.count
             if tags.count == 1 {
                 newItem.propertyTag = tags[0]
                 newItem.propertyTagRange = nil

--- a/RoomRoster/Views/InventoryView.swift
+++ b/RoomRoster/Views/InventoryView.swift
@@ -368,8 +368,13 @@ struct InventoryView: View {
                                 VStack(alignment: .leading) {
                                     Text(item.name).font(.headline)
                                     Text(l10n.status(item.status.label))
-                                    if let tagString = item.propertyTagRange?.stringValue() ?? item.propertyTag?.label {
-                                        Text(l10n.tag(tagString))
+                                    if let range = item.propertyTagRange {
+                                        let label = range.tags.count > 1 ? l10n.tags(range.stringValue()) : l10n.tag(range.stringValue())
+                                        Text(label)
+                                            .font(.subheadline)
+                                            .foregroundColor(.gray)
+                                    } else if let tag = item.propertyTag?.label {
+                                        Text(l10n.tag(tag))
                                             .font(.subheadline)
                                             .foregroundColor(.gray)
                                     }
@@ -388,8 +393,13 @@ struct InventoryView: View {
                                     VStack(alignment: .leading) {
                                         Text(item.name).font(.headline)
                                         Text(l10n.status(item.status.label))
-                                        if let tagString = item.propertyTagRange?.stringValue() ?? item.propertyTag?.label {
-                                            Text(l10n.tag(tagString))
+                                        if let range = item.propertyTagRange {
+                                            let label = range.tags.count > 1 ? l10n.tags(range.stringValue()) : l10n.tag(range.stringValue())
+                                            Text(label)
+                                                .font(.subheadline)
+                                                .foregroundColor(.gray)
+                                        } else if let tag = item.propertyTag?.label {
+                                            Text(l10n.tag(tag))
                                                 .font(.subheadline)
                                                 .foregroundColor(.gray)
                                         }
@@ -401,7 +411,6 @@ struct InventoryView: View {
                                         }
                                     }
                                 }
-                                .buttonStyle(.plain)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .contentShape(Rectangle())
 #endif

--- a/RoomRosterTests/ItemValidatorTests.swift
+++ b/RoomRosterTests/ItemValidatorTests.swift
@@ -25,13 +25,13 @@ final class ItemValidatorTests: XCTestCase {
             propertyTag: PropertyTag(rawValue: "A0001"),
             purchaseReceiptURL: nil
         )
-        XCTAssertThrowsError(try ItemValidator.validateTags("A0001", quantity: 1, currentItemID: nil, allItems: [item])) { error in
+        XCTAssertThrowsError(try ItemValidator.validateTags("A0001", currentItemID: nil, allItems: [item])) { error in
             XCTAssertEqual(error as? ItemValidationError, .duplicateTag)
         }
     }
 
     func testValidateTagSuccess() throws {
-        let tags = try ItemValidator.validateTags("A0001", quantity: 1, currentItemID: nil, allItems: [])
+        let tags = try ItemValidator.validateTags("A0001", currentItemID: nil, allItems: [])
         XCTAssertEqual(tags, [PropertyTag(rawValue: "A0001")!])
     }
 
@@ -50,7 +50,7 @@ final class ItemValidatorTests: XCTestCase {
 
     func testValidateCrossLetterRangeThrows() {
         XCTAssertThrowsError(
-            try ItemValidator.validateTags("A1000-B1000", quantity: 2, currentItemID: nil, allItems: [])
+            try ItemValidator.validateTags("A1000-B1000", currentItemID: nil, allItems: [])
         ) { error in
             XCTAssertEqual(error as? ItemValidationError, .invalidTagFormat)
         }


### PR DESCRIPTION
## Summary
- Ensure inventory rows navigate to item details and show plural tag labels
- Make tag list drive item quantity during creation
- Support optional quantity validation for property tags

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme RoomRoster -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ea825354832c86d67893f0c626b8