### PR TITLE
Exclude barcode scanner from macOS

### DIFF
--- a/RoomRoster.xcodeproj/project.pbxproj
+++ b/RoomRoster.xcodeproj/project.pbxproj
@@ -99,9 +99,9 @@
 		C616CDE1A2B34C5D67890ABE /* SalesDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C616CDE1A2B34C5D67890ABD /* SalesDetailsView.swift */; };
 		CE2487F2AA23494BBE56993D /* ReportsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12FE82B0693248D49E8D77BB /* ReportsViewModel.swift */; };
 		DE7D257232324BDDB96C6F37 /* RoomServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614508236AFA4269887FF35A /* RoomServiceTests.swift */; };
-                E0B282C5B6FF4AADB74F1235 /* DocumentPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B282C5B6FF4AADB74F1234 /* DocumentPickerView.swift */; };
-                AF92508CC3AD4558844194AA /* BarcodeScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2987006832490F89CFB17C /* BarcodeScannerView.swift */; };
-                E9FBF450607D494DA1894333 /* MockNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF137618CD644A1997B55ED6 /* MockNetworkService.swift */; };
+		E0B282C5B6FF4AADB74F1235 /* DocumentPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B282C5B6FF4AADB74F1234 /* DocumentPickerView.swift */; };
+		AF92508CC3AD4558844194AA /* BarcodeScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2987006832490F89CFB17C /* BarcodeScannerView.swift */; platformFilter = ios; };
+		E9FBF450607D494DA1894333 /* MockNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF137618CD644A1997B55ED6 /* MockNetworkService.swift */; };
 		EC28A959CE63441E9F3C1048 /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EC0F7257914A11A7589F29 /* ShareSheet.swift */; };
                 FDB33D97700C2EF04190FA52 /* GmailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C01D35FCE10EB02BEFD65D29 /* GmailService.swift */; };
                 FB42C5677D8D477793E2A66E /* PlatformImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA014E93EE2475992EB91B0 /* PlatformImage.swift */; };

--- a/RoomRoster/Views/BarcodeScannerView.swift
+++ b/RoomRoster/Views/BarcodeScannerView.swift
@@ -1,4 +1,4 @@
-#if canImport(AVFoundation) && !targetEnvironment(macCatalyst)
+#if canImport(AVFoundation) && os(iOS)
 import SwiftUI
 import AVFoundation
 import Vision

--- a/RoomRoster/Views/CreateItemView.swift
+++ b/RoomRoster/Views/CreateItemView.swift
@@ -384,6 +384,7 @@ struct CreateItemView: View {
         .onChange(of: inventory.rooms) { newRooms in
             viewModel.rooms = newRooms
         }
+#if os(iOS)
         .sheet(isPresented: $showScanner) {
             BarcodeScannerView { code in
                 viewModel.propertyTagInput = code
@@ -391,20 +392,18 @@ struct CreateItemView: View {
                 showScanner = false
             }
         }
+#endif
     }
 
     private var scanButton: some View {
-        #if targetEnvironment(macCatalyst)
-        Button(action: {}) {
-            Image(systemName: "barcode.viewfinder")
-        }
-        .disabled(true)
-        #else
+        #if os(iOS)
         Button {
             showScanner = true
         } label: {
             Image(systemName: "barcode.viewfinder")
         }
+        #else
+        EmptyView()
         #endif
     }
 

--- a/RoomRoster/Views/EditItemView.swift
+++ b/RoomRoster/Views/EditItemView.swift
@@ -407,6 +407,7 @@ struct EditItemView: View {
         .task {
             await viewModel.loadRooms()
         }
+#if os(iOS)
         .sheet(isPresented: $showScanner) {
             BarcodeScannerView { code in
                 propertyTagInput = code
@@ -414,20 +415,18 @@ struct EditItemView: View {
                 showScanner = false
             }
         }
+#endif
     }
 
     private var scanButton: some View {
-        #if targetEnvironment(macCatalyst)
-        Button(action: {}) {
-            Image(systemName: "barcode.viewfinder")
-        }
-        .disabled(true)
-        #else
+        #if os(iOS)
         Button {
             showScanner = true
         } label: {
             Image(systemName: "barcode.viewfinder")
         }
+        #else
+        EmptyView()
         #endif
     }
 

--- a/RoomRoster/Views/InventoryView.swift
+++ b/RoomRoster/Views/InventoryView.swift
@@ -114,14 +114,6 @@ struct InventoryView: View {
 #if os(macOS)
             ToolbarItemGroup(placement: .primaryAction) {
                 if sheets.currentSheet != nil {
-#if !targetEnvironment(macCatalyst)
-                    Button(action: {
-                        Logger.action("Pressed Scan Toolbar")
-                        showingScanner = true
-                    }) {
-                        Label("Scan", systemImage: "barcode.viewfinder")
-                    }
-#endif
                     Button(action: { openCreateItem() }) {
                         Label(l10n.addItemButton, systemImage: "plus")
                     }
@@ -129,14 +121,12 @@ struct InventoryView: View {
             }
 #else
             if sheets.currentSheet != nil {
-#if !targetEnvironment(macCatalyst)
                 Button(action: {
                     Logger.action("Pressed Scan Toolbar")
                     showingScanner = true
                 }) {
                     Label("Scan", systemImage: "barcode.viewfinder")
                 }
-#endif
                 Button(action: { openCreateItem() }) {
                     Label(l10n.addItemButton, systemImage: "plus")
                 }
@@ -144,7 +134,7 @@ struct InventoryView: View {
 #endif
         }
         .navigationTitle(l10n.title)
-#if !targetEnvironment(macCatalyst)
+#if os(iOS)
         .sheet(isPresented: $showingScanner) {
             BarcodeScannerView { code in
                 handleScanned(code)
@@ -327,7 +317,7 @@ struct InventoryView: View {
 
             if sheets.currentSheet != nil {
                 VStack(spacing: 16) {
-#if !targetEnvironment(macCatalyst)
+#if os(iOS)
                     Button(action: {
                         Logger.action("Pressed Scan Button")
                         HapticManager.shared.impact()


### PR DESCRIPTION
## Summary
- Limit BarcodeScannerView implementation to iOS and remove macOS integrations
- Hide barcode scanning UI on macOS in CreateItem, EditItem, and Inventory views
- Restrict BarcodeScannerView.swift to iOS in the project file

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f38667e4832cb0be0d7b903b8202