### PR TITLE
Remove noisy sign-in log

### DIFF
--- a/RoomRoster/Utilities/AuthenticationManager.swift
+++ b/RoomRoster/Utilities/AuthenticationManager.swift
@@ -65,7 +65,6 @@ class AuthenticationManager: ObservableObject {
             await SpreadsheetManager.shared.loadSheets()
             return true
         } catch {
-            Logger.log(error, extra: ["description": "Failed restoring sign in"])
             return false
         }
     }


### PR DESCRIPTION
## Summary
- stop logging expected errors when silently restoring a previous sign-in fails

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project RoomRoster.xcodeproj -scheme RoomRoster -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e932fcac832ca68209666533d1cc