### PR TITLE
Show loading spinner while images load

### DIFF
--- a/RoomRoster/Views/Components/ReceiptImageView.swift
+++ b/RoomRoster/Views/Components/ReceiptImageView.swift
@@ -21,11 +21,8 @@ struct RemoteImageView: View {
                         .frame(width: height, height: height)
                         .foregroundColor(.red.opacity(0.8))
                 default:
-                    Image(systemName: "photo")
-                        .resizable()
-                        .scaledToFit()
+                    ProgressView()
                         .frame(width: height, height: height)
-                        .foregroundColor(.secondary.opacity(0.5))
                 }
             }
         } else {
@@ -60,11 +57,8 @@ struct ReceiptImageView: View {
                         .frame(width: height, height: height)
                         .foregroundColor(.red.opacity(0.8))
                 default:
-                    Image(systemName: "photo")
-                        .resizable()
-                        .scaledToFit()
+                    ProgressView()
                         .frame(width: height, height: height)
-                        .foregroundColor(.secondary.opacity(0.5))
                 }
             }
         } else if let urlString, !urlString.isEmpty {


### PR DESCRIPTION
## Summary
- show `ProgressView` while remote item and receipt images load

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fa07cdd0832c9293e763970d5d56